### PR TITLE
Fix indentation and update workflow permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,9 +23,11 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
-
-    steps:
+      id-token: steps
+      with:
+  allowed_bots: '*'
+  
+  steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration. The `id-token` permission for the workflow is now set to `steps` instead of `write`, and an `allowed_bots` parameter is added with a wildcard value.

- Updated workflow permissions and configuration:
  * Changed the `id-token` permission from `write` to `steps` and added `allowed_bots: '*'` to the workflow configuration in `.github/workflows/claude-code-review.yml`.