### PR TITLE
Add GitHub Actions workflow to sync hodie from Google Drive

### DIFF
--- a/.github/workflows/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/.github/workflows/sync-hodie.yml
@@ -34,7 +34,11 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add hodie/
+          if [ -d hodie ]; then
+            git add hodie/
+          else
+            echo "hodie/ does not exist — nothing to stage."
+          fi
           if git diff --cached --quiet; then
             echo "No new files — nothing to commit."
           else

--- a/.github/workflows/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/.github/workflows/sync-hodie.yml
@@ -1,0 +1,45 @@
+name: Sync hodie from Google Drive
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # noon UTC daily
+  workflow_dispatch:        # manual trigger from the GitHub Actions tab
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # needed to commit and push synced files back to the repo
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Sync hodie folder from Google Drive
+        env:
+          GDRIVE_SERVICE_ACCOUNT_KEY: ${{ secrets.GDRIVE_SERVICE_ACCOUNT_KEY }}
+        run: python scripts/sync_hodie.py
+
+      - name: Commit and push synced files
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add hodie/
+          if git diff --cached --quiet; then
+            echo "No new files — nothing to commit."
+          else
+            git commit -m "hodie: sync $(date -u '+%Y-%m-%d')"
+            git pull --rebase
+            git push
+          fi
+          

--- a/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/sync-hodie.yml
@@ -13,22 +13,38 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
 
       - name: Sync hodie folder from Google Drive
         env:
           GDRIVE_SERVICE_ACCOUNT_KEY: ${{ secrets.GDRIVE_SERVICE_ACCOUNT_KEY }}
-        run: python scripts/sync_hodie.py
+        run: |
+          set -euo pipefail
+
+          if [ -f .scripts/sync_hodie.py ]; then
+            python .scripts/sync_hodie.py
+          elif [ -f .scripts/sync_hodie.sh ]; then
+            bash .scripts/sync_hodie.sh
+          elif [ -f scripts/sync_hodie.py ]; then
+            python scripts/sync_hodie.py
+          elif [ -f scripts/sync_hodie.sh ]; then
+            bash scripts/sync_hodie.sh
+          else
+            echo "No hodie sync implementation found in .scripts/ or scripts/." >&2
+            exit 1
+          fi
 
       - name: Commit and push synced files
         run: |
@@ -46,4 +62,3 @@ jobs:
             git pull --rebase
             git push
           fi
-          


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate syncing the `hodie` folder from Google Drive into the repository. The workflow runs daily at noon UTC and can also be triggered manually.

**New workflow for automated syncing:**

* Added `.github/workflows/sync-hodie.yml` to schedule a daily (and manual) sync of the `hodie` folder from Google Drive using a Python script and service account credentials. The workflow checks out the repo, sets up Python, installs dependencies, runs the sync script, and commits any changes back to the repository.This workflow syncs the 'hodie' folder from Google Drive daily and allows manual triggers.