### PR TITLE
Add workflow to automate hodie synchronization from Google Drive

### DIFF
--- a/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/sync-hodie.yml
@@ -1,0 +1,44 @@
+name: Sync hodie from Google Drive
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # noon UTC daily
+  workflow_dispatch:        # manual trigger from the GitHub Actions tab
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # needed to commit and push synced files back to the repo
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Sync hodie folder from Google Drive
+        env:
+          GDRIVE_SERVICE_ACCOUNT_KEY: ${{ secrets.GDRIVE_SERVICE_ACCOUNT_KEY }}
+        run: python scripts/sync_hodie.py
+
+      - name: Commit and push synced files
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add hodie/
+          if git diff --cached --quiet; then
+            echo "No new files — nothing to commit."
+          else
+            git commit -m "hodie: sync $(date -u '+%Y-%m-%d')"
+            git pull --rebase
+            git push
+          fi

--- a/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/sync-hodie.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install .
 
       - name: Sync hodie folder from Google Drive
         env:

--- a/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/sync-hodie.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Sync hodie folder from Google Drive
         env:
           GDRIVE_SERVICE_ACCOUNT_KEY: ${{ secrets.GDRIVE_SERVICE_ACCOUNT_KEY }}
-        run: python scripts/sync_hodie.py
+        run: python .github/workflows/scripts/sync_hodie.py
 
       - name: Commit and push synced files
         run: |

--- a/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/sync-hodie.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 12 * * *'  # noon UTC daily
   workflow_dispatch:        # manual trigger from the GitHub Actions tab
 
+concurrency:
+  group: sync-hodie
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/sync-hodie.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/sync-hodie.yml
+++ b/.github/workflows/sync-hodie.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add hodie/
+          git add --all -- hodie/
           if git diff --cached --quiet; then
             echo "No new files — nothing to commit."
           else


### PR DESCRIPTION
This workflow automates the synchronization of the 'hodie' folder from Google Drive, ensuring that the latest files are regularly updated in the repository.
This pull request introduces a new GitHub Actions workflow to automate syncing the `hodie` folder from Google Drive into the repository. The workflow is scheduled to run daily at noon UTC and can also be triggered manually.

**New workflow for automated folder sync:**

* Added `.github/workflows/sync-hodie.yml` to set up a daily (and manual) workflow that:
  * Checks out the repository and sets up Python 3.10.
  * Installs dependencies from `requirements.txt`.
  * Runs `scripts/sync_hodie.py` to sync the `hodie` folder from Google Drive using a service account key stored in GitHub secrets.
  * Commits and pushes any changes to the `hodie/` directory back to the repository.