### PR TITLE
Gate pylint workflow by score threshold

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -30,23 +30,59 @@ jobs:
         pip install pylint
 
     - name: Lint active codebase
+      env:
+        PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
         # Only lint active code directories, not archived/legacy content
         set -o pipefail
-        pylint_log="${RUNNER_TEMP:-/tmp}/pylint-output-${{ matrix.python-version }}.log"
+        temp_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+        mkdir -p "$temp_dir"
+        safe_python_version="${PYTHON_VERSION//./-}"
+        pylint_log="$(mktemp "$temp_dir/pylint-output-${safe_python_version}-XXXXXX.log")"
+        trap 'rm -f "$pylint_log"' EXIT
+        set +e
         pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc | tee "$pylint_log"
         pylint_exit="${PIPESTATUS[0]}"
+        set -e
 
-        score="$(grep -Eo 'rated at [0-9]+\.[0-9]+/10' "$pylint_log" | tail -n 1 | sed -E 's/rated at ([0-9]+\.[0-9]+)\/10/\1/')"
-        fail_under="$(grep -E '^[[:space:]]*fail-under[[:space:]]*=' pyproject.toml | head -n 1 | sed -E 's/.*=[[:space:]]*([0-9]+(\.[0-9]+)?).*/\1/')"
+        # Pylint 4.x prints "Your code has been rated at X/10"; use the final summary line.
+        score="$(grep -E '^Your code has been rated at [0-9]+(\.[0-9]+)?/10' "$pylint_log" | tail -n 1 | sed -E 's/^Your code has been rated at ([0-9]+(\.[0-9]+)?)\/10.*/\1/')"
+        fail_under="$(awk '
+          /^\[tool\.pylint\.main\]/ { in_section=1; next }
+          /^\[/ { in_section=0 }
+          in_section && /^[[:space:]]*fail-under[[:space:]]*=/ {
+            gsub(/^[^=]*=[[:space:]]*/, "", $0)
+            gsub(/[[:space:]]/, "", $0)
+            print $0
+            exit
+          }
+        ' pyproject.toml)"
 
-        if [ -z "$score" ] || [ -z "$fail_under" ]; then
-          echo "Unable to parse pylint score or fail-under threshold."
+        if [ -z "$score" ]; then
+          echo "Unable to parse pylint score from output."
           exit 1
         fi
 
-        python -c "import sys; sys.exit(0 if float('$score') >= float('$fail_under') else 1)"
-        if [ "$?" -ne 0 ]; then
+        if [ -z "$fail_under" ]; then
+          echo "Unable to parse fail-under threshold from pyproject.toml."
+          exit 1
+        fi
+
+        if ! python - "$score" "$fail_under" <<'PY'
+import sys
+
+score_value = sys.argv[1]
+threshold_value = sys.argv[2]
+
+try:
+    score = float(score_value)
+    threshold = float(threshold_value)
+except ValueError as exc:
+    raise SystemExit(f"Invalid numeric value for score/threshold: {exc}")
+
+raise SystemExit(0 if score >= threshold else 1)
+PY
+        then
           echo "Pylint score $score is below fail-under threshold $fail_under."
           exit 1
         fi

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -46,7 +46,12 @@ jobs:
         set -e
 
         # Pylint 4.x prints "Your code has been rated at X/10"; use the final summary line.
-        score="$(grep -E '^Your code has been rated at [0-9]+(\.[0-9]+)?/10' "$pylint_log" | tail -n 1 | sed -E 's/^Your code has been rated at ([0-9]+(\.[0-9]+)?)\/10.*/\1/')"
+        score="$(
+          grep -E '^Your code has been rated at -?[0-9]+(\.[0-9]+)?/10' "$pylint_log" \
+            | tail -n 1 \
+            | sed -E 's/^Your code has been rated at (-?[0-9]+(\.[0-9]+)?)\/10.*/\1/' \
+            || true
+        )"
         fail_under="$(awk '
           /^\[tool\.pylint\.main\]/ { in_section=1; next }
           /^\[/ { in_section=0 }

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -32,4 +32,26 @@ jobs:
     - name: Lint active codebase
       run: |
         # Only lint active code directories, not archived/legacy content
-        pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc
+        set -o pipefail
+        pylint_log="${RUNNER_TEMP:-/tmp}/pylint-output-${{ matrix.python-version }}.log"
+        pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc | tee "$pylint_log"
+        pylint_exit="${PIPESTATUS[0]}"
+
+        score="$(grep -Eo 'rated at [0-9]+\.[0-9]+/10' "$pylint_log" | tail -n 1 | sed -E 's/rated at ([0-9]+\.[0-9]+)\/10/\1/')"
+        fail_under="$(grep -E '^[[:space:]]*fail-under[[:space:]]*=' pyproject.toml | head -n 1 | sed -E 's/.*=[[:space:]]*([0-9]+(\.[0-9]+)?).*/\1/')"
+
+        if [ -z "$score" ] || [ -z "$fail_under" ]; then
+          echo "Unable to parse pylint score or fail-under threshold."
+          exit 1
+        fi
+
+        python -c "import sys; sys.exit(0 if float('$score') >= float('$fail_under') else 1)"
+        if [ "$?" -ne 0 ]; then
+          echo "Pylint score $score is below fail-under threshold $fail_under."
+          exit 1
+        fi
+
+        echo "Pylint score $score meets fail-under threshold $fail_under."
+        if [ "$pylint_exit" -ne 0 ]; then
+          echo "Pylint returned exit code $pylint_exit due to warnings/messages, but score gate passed."
+        fi


### PR DESCRIPTION
This pull request enhances the GitHub Actions workflow for running Pylint by adding logic to parse and enforce the minimum code quality threshold (`fail-under`) from `pyproject.toml`. The workflow now captures the Pylint score, compares it to the configured threshold, and fails the job if the score is too low, independent of Pylint's exit code. This ensures more consistent enforcement of linting standards.

**Improvements to linting workflow:**

* Captures Pylint output to a temporary log file and extracts the final code quality score for evaluation.
* Parses the `fail-under` threshold from `pyproject.toml` and compares it to the extracted Pylint score, failing the workflow if the score is below the threshold.
* Adds robust error handling for cases where the score or threshold cannot be parsed, ensuring the workflow fails with a clear message.
* Allows the workflow to pass even if Pylint returns a non-zero exit code (due to warnings), as long as the score meets the threshold, providing more flexibility in CI enforcement.