### PR TITLE
Enhance pylint workflow with improved gating and logging

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -37,6 +37,7 @@ jobs:
         set +e
         log_file=$(mktemp "${RUNNER_TEMP}/pylint-${GITHUB_RUN_ID:-local}-XXXXXX.log")
         pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc | tee "${log_file}"
+        pylint_exit=${PIPESTATUS[0]}
         set -e
         export PYLINT_LOG_FILE="${log_file}"
 
@@ -46,11 +47,12 @@ jobs:
         import sys
         from pathlib import Path
 
-        number_pattern = r"[0-9]+(?:\.[0-9]+)?"
+        score_number_pattern = r"-?[0-9]+(?:\.[0-9]+)?"
+        fail_under_number_pattern = r"[0-9]+(?:\.[0-9]+)?"
         error_context_lines = 5
         log_path = Path(os.environ["PYLINT_LOG_FILE"])
         log_text = log_path.read_text(encoding="utf-8")
-        score_match = re.search(rf"rated at ({number_pattern})/10", log_text)
+        score_match = re.search(rf"rated at ({score_number_pattern})/10", log_text)
         if not score_match:
             excerpt = "\n".join(log_text.strip().splitlines()[-error_context_lines:])
             raise SystemExit(
@@ -60,7 +62,9 @@ jobs:
         score = float(score_match.group(1))
 
         pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
-        fail_under_match = re.search(rf"fail-under\s*=\s*({number_pattern})", pyproject_text)
+        fail_under_match = re.search(
+            rf"fail-under\s*=\s*({fail_under_number_pattern})", pyproject_text
+        )
         if not fail_under_match:
             raise SystemExit("Unable to parse fail-under from pyproject.toml.")
         fail_under = float(fail_under_match.group(1))
@@ -69,3 +73,9 @@ jobs:
         if score < fail_under:
             sys.exit(1)
         PY
+
+        fatal_bits=$((1 | 2 | 32))
+        if (( pylint_exit & fatal_bits )); then
+          echo "Pylint exited with fatal/error/usage status: ${pylint_exit}"
+          exit "${pylint_exit}"
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,5 @@
 - Repaired pylint CI behavior to gate on configured `fail-under` score from `pyproject.toml`
   instead of failing on pylint's raw non-zero exit code when messages are present.
 - Improved workflow diagnostics by printing parsed pylint score and threshold in job output.
-- Fixed repository metadata by removing invalid gitlink entry `plexus (1)` that caused
+- Fixed repository metadata by removing invalid gitlink entry `plexus` that caused
   GitHub Actions post-job submodule cleanup warnings.


### PR DESCRIPTION
This pull request improves the reliability and clarity of the CI linting workflow and repository metadata management. The main update changes the pylint check to gate on the configured `fail-under` score from `pyproject.toml` rather than failing on any lint messages, and enhances diagnostics by printing the parsed score and threshold. Additionally, it removes an invalid submodule reference that was causing GitHub Actions warnings.

**CI workflow improvements:**

* Updated the `.github/workflows/pylint.yml` workflow to parse the pylint score from the log and compare it against the `fail-under` threshold specified in `pyproject.toml`, failing the job only if the score is below the threshold. The workflow now prints both the parsed score and the threshold for better diagnostics.

**Repository metadata fixes:**

* Removed the invalid submodule reference `plexus (1)` to resolve GitHub Actions post-job submodule cleanup warnings.

**Documentation:**

* Added a changelog entry summarizing the repaired pylint CI behavior, improved diagnostics, and the metadata fix.