### PR TITLE
Fix and harden pylint score-gating workflow

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -32,4 +32,49 @@ jobs:
     - name: Lint active codebase
       run: |
         # Only lint active code directories, not archived/legacy content
-        pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc
+        set +e
+        pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc | tee pylint-output.txt
+        PYLINT_EXIT=${PIPESTATUS[0]}
+        set -e
+
+        SCORE=$(python - <<'PY'
+        import re
+        from pathlib import Path
+
+        output = Path("pylint-output.txt").read_text(encoding="utf-8")
+        match = re.search(r"rated at ([0-9.]+)/10", output)
+        print(match.group(1) if match else "")
+        PY
+        )
+
+        FAIL_UNDER=$(python - <<'PY'
+        import tomllib
+        from pathlib import Path
+
+        config = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+        print(config["tool"]["pylint"]["main"]["fail-under"])
+        PY
+        )
+
+        if [ -z "$SCORE" ]; then
+          echo "Could not parse pylint score from output."
+          echo "pylint exit code: ${PYLINT_EXIT}"
+          exit 1
+        fi
+
+        echo "pylint exit code: ${PYLINT_EXIT}"
+        echo "pylint score: ${SCORE}"
+        echo "required fail-under: ${FAIL_UNDER}"
+
+        python - <<'PY' "$SCORE" "$FAIL_UNDER"
+        import sys
+
+        score = float(sys.argv[1])
+        fail_under = float(sys.argv[2])
+
+        if score < fail_under:
+          print(f"Score {score:.2f} is below fail-under {fail_under:.2f}")
+          raise SystemExit(1)
+
+        print(f"Score {score:.2f} meets fail-under {fail_under:.2f}")
+        PY

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -66,6 +66,10 @@ jobs:
         echo "pylint score: ${SCORE}"
         echo "required fail-under: ${FAIL_UNDER}"
 
+        if (( PYLINT_EXIT & 35 )); then
+          echo "pylint reported fatal/error/usage conditions (exit code: ${PYLINT_EXIT})."
+          exit 1
+        fi
         python - <<'PY' "$SCORE" "$FAIL_UNDER"
         import sys
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -69,8 +69,17 @@ jobs:
         python - <<'PY' "$SCORE" "$FAIL_UNDER"
         import sys
 
-        score = float(sys.argv[1])
-        fail_under = float(sys.argv[2])
+        try:
+          score = float(sys.argv[1])
+        except ValueError as exc:
+          print(f"Could not parse SCORE as float: {sys.argv[1]!r}")
+          raise SystemExit(1) from exc
+
+        try:
+          fail_under = float(sys.argv[2])
+        except ValueError as exc:
+          print(f"Could not parse FAIL_UNDER as float: {sys.argv[2]!r}")
+          raise SystemExit(1) from exc
 
         if score < fail_under:
           print(f"Score {score:.2f} is below fail-under {fail_under:.2f}")


### PR DESCRIPTION
This pull request enhances the `pylint` workflow in `.github/workflows/pylint.yml` by making the linting process more robust and configurable. The workflow now parses the pylint score from the output and compares it against a configurable threshold defined in `pyproject.toml`, failing the job if the score is too low. This change helps enforce code quality standards consistently across the codebase.

**Linting workflow improvements:**

* Captures the pylint output to a file, parses the score, and compares it to a `fail-under` threshold specified in `pyproject.toml`, failing the workflow if the score is below the threshold.
* Adds error handling for missing or unparsable pylint scores and provides clear output for both success and failure cases.