### PR TITLE
Enhance pylint workflow with score gating and compatibility fixes

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -48,11 +48,32 @@ jobs:
         )
 
         FAIL_UNDER=$(python - <<'PY'
-        import tomllib
+        import re
         from pathlib import Path
 
-        config = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-        print(config["tool"]["pylint"]["main"]["fail-under"])
+        pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
+        config = None
+        try:
+          import tomllib  # Python 3.11+
+          config = tomllib.loads(pyproject_text)
+        except ModuleNotFoundError:
+          try:
+            import tomli as tomllib  # type: ignore[import-not-found]
+            config = tomllib.loads(pyproject_text)
+          except ModuleNotFoundError:
+            config = None
+
+        if config is not None:
+          print(config["tool"]["pylint"]["main"]["fail-under"])
+        else:
+          match = re.search(
+            r"^\s*fail-under\s*=\s*([0-9]+(?:\.[0-9]+)?)\s*$",
+            pyproject_text,
+            re.MULTILINE,
+          )
+          if not match:
+            raise SystemExit("Could not parse fail-under from pyproject.toml")
+          print(match.group(1))
         PY
         )
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -59,7 +59,7 @@ jobs:
             import tomli as tomllib  # type: ignore[import-not-found]
           except ModuleNotFoundError as exc:
             raise SystemExit(
-              "No TOML parser available: install tomli on Python <3.11."
+              "TOML parsing failed: neither tomllib nor tomli is available."
             ) from exc
 
         config = tomllib.loads(pyproject_text)

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        # tomli keeps pyproject parsing compatible with Python 3.10 runners.
         pip install pylint tomli
 
     - name: Lint active codebase
@@ -54,7 +55,12 @@ jobs:
         try:
           import tomllib  # Python 3.11+
         except ModuleNotFoundError:
-          import tomli as tomllib  # type: ignore[import-not-found]
+          try:
+            import tomli as tomllib  # type: ignore[import-not-found]
+          except ModuleNotFoundError as exc:
+            raise SystemExit(
+              "No TOML parser available: install tomli on Python <3.11."
+            ) from exc
 
         config = tomllib.loads(pyproject_text)
         print(config["tool"]["pylint"]["main"]["fail-under"])

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -43,7 +43,11 @@ jobs:
         set +e
         pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc | tee "$pylint_log"
         pylint_exit="${PIPESTATUS[0]}"
-        set -e
+        match = re.search(
+          r"^Your code has been rated at ([+-]?[0-9]+(?:\.[0-9]+)?)/10(?:\s|$)",
+          output,
+          re.MULTILINE,
+        )
 
         # Pylint 4.x prints "Your code has been rated at X/10"; use the final summary line.
         score="$(

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -32,4 +32,49 @@ jobs:
     - name: Lint active codebase
       run: |
         # Only lint active code directories, not archived/legacy content
-        pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc
+        set +e
+        pylint crawler_pixel8/ redundancy_entity/ --rcfile=.pylintrc | tee pylint-output.txt
+        PYLINT_EXIT=${PIPESTATUS[0]}
+        set -e
+
+        SCORE=$(python - <<'PY'
+        import re
+        from pathlib import Path
+
+        output = Path("pylint-output.txt").read_text(encoding="utf-8")
+        match = re.search(r"rated at ([0-9.]+)/10", output)
+        print(match.group(1) if match else "")
+        PY
+        )
+
+        FAIL_UNDER=$(python - <<'PY'
+        import tomllib
+        from pathlib import Path
+
+        config = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+        print(config["tool"]["pylint"]["main"]["fail-under"])
+        PY
+        )
+
+        if [ -z "$SCORE" ]; then
+          echo "Could not parse pylint score from output."
+          echo "pylint exit code: ${PYLINT_EXIT}"
+          exit 1
+        fi
+
+        echo "pylint exit code: ${PYLINT_EXIT}"
+        echo "pylint score: ${SCORE}"
+        echo "required fail-under: ${FAIL_UNDER}"
+
+        python - <<'PY' "$SCORE" "$FAIL_UNDER"
+        import sys
+
+        score = float(sys.argv[1])
+        fail_under = float(sys.argv[2])
+
+        if score < fail_under:
+          print(f"Score {score:.2f} is below fail-under {fail_under:.2f}")
+          raise SystemExit(1)
+
+        print(f"Score {score:.2f} meets fail-under {fail_under:.2f}")
+        PY

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -66,6 +66,10 @@ jobs:
         echo "pylint score: ${SCORE}"
         echo "required fail-under: ${FAIL_UNDER}"
 
+        if (( PYLINT_EXIT & 35 )); then
+          echo "pylint reported fatal/error/usage conditions (exit code: ${PYLINT_EXIT})."
+          exit 1
+        fi
         python - <<'PY' "$SCORE" "$FAIL_UNDER"
         import sys
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install pylint tomli
 
     - name: Lint active codebase
       run: |
@@ -48,32 +48,16 @@ jobs:
         )
 
         FAIL_UNDER=$(python - <<'PY'
-        import re
         from pathlib import Path
 
         pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
-        config = None
         try:
           import tomllib  # Python 3.11+
-          config = tomllib.loads(pyproject_text)
         except ModuleNotFoundError:
-          try:
-            import tomli as tomllib  # type: ignore[import-not-found]
-            config = tomllib.loads(pyproject_text)
-          except ModuleNotFoundError:
-            config = None
+          import tomli as tomllib  # type: ignore[import-not-found]
 
-        if config is not None:
-          print(config["tool"]["pylint"]["main"]["fail-under"])
-        else:
-          match = re.search(
-            r"^\s*fail-under\s*=\s*([0-9]+(?:\.[0-9]+)?)\s*$",
-            pyproject_text,
-            re.MULTILINE,
-          )
-          if not match:
-            raise SystemExit("Could not parse fail-under from pyproject.toml")
-          print(match.group(1))
+        config = tomllib.loads(pyproject_text)
+        print(config["tool"]["pylint"]["main"]["fail-under"])
         PY
         )
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -69,8 +69,17 @@ jobs:
         python - <<'PY' "$SCORE" "$FAIL_UNDER"
         import sys
 
-        score = float(sys.argv[1])
-        fail_under = float(sys.argv[2])
+        try:
+          score = float(sys.argv[1])
+        except ValueError as exc:
+          print(f"Could not parse SCORE as float: {sys.argv[1]!r}")
+          raise SystemExit(1) from exc
+
+        try:
+          fail_under = float(sys.argv[2])
+        except ValueError as exc:
+          print(f"Could not parse FAIL_UNDER as float: {sys.argv[2]!r}")
+          raise SystemExit(1) from exc
 
         if score < fail_under:
           print(f"Score {score:.2f} is below fail-under {fail_under:.2f}")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [Unreleased]
+
+### Fixed
+- Repaired the Pylint GitHub Actions workflow on Python 3.10 by removing a hard dependency on `tomllib` during `fail-under` parsing.
+
+### Changed
+- Upgraded Pylint workflow `fail-under` parsing to use a compatibility path: `tomllib` (3.11+), optional `tomli`, then a safe regex fallback from `pyproject.toml`.
+- Preserved existing CI behavior: fatal/error lint exits still fail immediately, and score gating remains enforced by `tool.pylint.main.fail-under`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Repaired the Pylint GitHub Actions workflow on Python 3.10 by removing a hard dependency on `tomllib` during `fail-under` parsing.
+- Resolved Pylint workflow failure on Python < 3.11 by implementing a compatibility path for pyproject.toml parsing.
 
 ### Changed
-- Upgraded Pylint workflow `fail-under` parsing to use a compatibility path: `tomllib` (3.11+), optional `tomli`, then a safe regex fallback from `pyproject.toml`.
-- Preserved existing CI behavior: fatal/error lint exits still fail immediately, and score gating remains enforced by `tool.pylint.main.fail-under`.
+- Enhanced Pylint workflow with clearer reporting of lint results and robust score gating enforcement.
 
 ## 2026-04-23
 


### PR DESCRIPTION
This pull request improves the Pylint GitHub Actions workflow for better compatibility with Python 3.10 and more robust handling of the `fail-under` score threshold. The workflow now conditionally uses `tomllib` or `tomli` for parsing `pyproject.toml`, ensuring compatibility across Python versions, and adds clearer reporting of lint results. The changelog has also been updated to document these improvements.

**Workflow compatibility and robustness:**

* Updated the Pylint workflow in `.github/workflows/pylint.yml` to install `tomli` alongside `pylint`, ensuring TOML parsing works on Python 3.10 runners where `tomllib` is unavailable. The workflow now tries `tomllib` (Python 3.11+), then `tomli`, and reports a clear error if neither is present.
* Enhanced the workflow to robustly parse the Pylint score and the `fail-under` threshold from `pyproject.toml`, with improved error handling and clearer output messages. The workflow preserves existing CI behavior: it still fails immediately on fatal/error/usage exit codes, and enforces the `fail-under` gating.

**Documentation:**

* Added a `CHANGELOG.md` file documenting the workflow fixes and improvements, including compatibility changes and the preservation of CI enforcement logic.