### PR TITLE
fix(ci): skip Claude review on bot actors without write access

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ !contains(fromJSON('["Copilot","copilot[bot]","github-actions[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/Eaprime1/hodie/sessions/2ac986ad-d198-4902-9f1a-7bb9ad8a7dd3