### PR TITLE
fix(ci): repair python-package-conda.yml and pylint.yml; add ♓ Pisces…

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,5 @@
 name: Pylint
+# ♓
 
 on:
   push:
@@ -56,40 +57,11 @@ jobs:
           echo "Pylint exited with fatal/error/usage bits set: ${pylint_exit}"
           exit "${pylint_exit}"
         fi
-        PY_FAIL_UNDER=$(python - <<'PY'
-import pathlib
-try:
-    import tomllib as toml_loader
-except ModuleNotFoundError:  # Python < 3.11
-    # Fallback for Python < 3.11 where tomllib is unavailable.
-    import tomli as toml_loader
-with open(pathlib.Path("pyproject.toml"), "rb") as f:
-    pyproject = toml_loader.load(f)
-print(pyproject["tool"]["pylint"]["main"]["fail-under"])
-PY
-)
-        PY_SCORE=$(python - <<PY
-import pathlib
-import re
-text = pathlib.Path("${pylint_log}").read_text(encoding="utf-8")
-match = re.search(r"rated at (-?[0-9]+(?:\.[0-9]+)?)/10", text)
-if not match:
-    raise SystemExit(
-        "Unable to parse pylint score from output. "
-        "The log may be truncated or pylint may have crashed."
-    )
-print(match.group(1))
-PY
-)
+        PY_FAIL_UNDER=$(python -c "import sys; t=__import__('tomllib' if sys.version_info>=(3,11) else 'tomli'); d=t.load(open('pyproject.toml','rb')); print(d['tool']['pylint']['main']['fail-under'])")
+        PY_SCORE=$(python -c "import re, pathlib, sys; m=re.search(r'rated at (-?[0-9]+(?:\.[0-9]+)?)/10', pathlib.Path('${pylint_log}').read_text(encoding='utf-8')); sys.exit('Unable to parse pylint score; log may be truncated') if not m else print(m.group(1))")
         echo "Pylint score: ${PY_SCORE}/10 (required: ${PY_FAIL_UNDER}/10)"
-        python - <<'PY' "${PY_SCORE}" "${PY_FAIL_UNDER}"
-import sys
-score = float(sys.argv[1])
-required = float(sys.argv[2])
-if score < required:
-    raise SystemExit(f"Pylint score {score}/10 is below required {required}/10.")
-print("Pylint score threshold satisfied.")
-PY
+        python -c "import sys; s,r=float('${PY_SCORE}'),float('${PY_FAIL_UNDER}'); print('Pylint score threshold satisfied.') if s>=r else sys.exit(f'Pylint score {s}/10 is below required {r}/10.')"
         if [ "$pylint_exit" -ne 0 ]; then
           echo "Pylint returned exit code $pylint_exit due to warnings/messages, but score gate passed."
         fi
+

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,115 +1,44 @@
-name: Python Package using Conda
+# Python Package — CI workflow
+# Lints with flake8 and runs the pytest suite using pip.
+# No conda or environment.yml required; dependencies come from pyproject.toml.
+# ♓
 
-on: [push]
+name: Python Package
+
+on: [push, pull_request]
 
 jobs:
-  build-linux:
+  build:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda env update --file environment.yml --name base
-    - name: Lint with flake8
-      run: |
-        conda install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        conda install pytest
-        pytest
-        
-- name: Setup Node.js environment
+      - uses: actions/checkout@v4
 
-  uses: actions/setup-node@v6.2.0
-  with:
-    # Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.
-    node-version: # optional
-    # File containing the version Spec of the version to use.  Examples: package.json, .nvmrc, .node-version, .tool-versions.
-    node-version-file: # optional
-    # Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default.
-    architecture: # optional
-    # Set this option if you want the action to check for the latest available version that satisfies the version spec.
-    check-latest: # optional
-    # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.
-    registry-url: # optional
-    # Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/).
-    scope: # optional
-    # Used to pull node distributions from node-versions. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
-    token: # optional, default is ${{ github.server_url == 'https://github.com' && github.token || '' }}
-    # Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.
-    cache: # optional
-    # Set to false to disable automatic caching. By default, caching is enabled when either devEngines.packageManager or the top-level packageManager field in package.json specifies npm as the package manager.
-    package-manager-cache: # optional, default is true
-    # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.
-    cache-dependency-path: # optional
-    # Used to specify an alternative mirror to download Node.js binaries from
-    mirror: # optional
-    # The token used as Authorization header when fetching from the mirror
-    mirror-token: # optional
-          
-        
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-            - name: Upload a Build Artifact
-  uses: actions/upload-artifact@v6.0.0
-  with:
-    # Artifact name
-    name: # optional, default is artifact
-    # A file, directory or wildcard pattern that describes what to upload
-    path: 
-    # The desired behavior if no files are found using the provided path.
-Available Options:
-  warn: Output a warning but do not fail the action
-  error: Fail the action with an error message
-  ignore: Do not output any warnings or errors, the action does not fail
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8 pytest pytest-asyncio
+          python -m pip install -e ".[dev]"
 
-    if-no-files-found: # optional, default is warn
-    # Duration after which artifact will expire in days. 0 means using default retention.
-Minimum 1 day. Maximum 90 days unless changed from the repository settings page.
+      - name: Lint with flake8
+        run: |
+          # Only lint active code directories, matching the pylint scope.
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 crawler_pixel8/ redundancy_entity/ tests/ \
+            --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings
+          flake8 crawler_pixel8/ redundancy_entity/ tests/ \
+            --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    retention-days: # optional
-    # The level of compression for Zlib to be applied to the artifact archive. The value can range from 0 to 9: - 0: No compression - 1: Best speed - 6: Default compression (same as GNU Gzip) - 9: Best compression Higher levels will result in better compression, but will take longer to complete. For large files that are not easily compressed, a value of 0 is recommended for significantly faster uploads.
-
-    compression-level: # optional, default is 6
-    # If true, an artifact with a matching name will be deleted before a new one is uploaded. If false, the action will fail if an artifact for the given name already exists. Does not fail if the artifact does not exist.
-
-    overwrite: # optional, default is false
-    # If true, hidden files will be included in the artifact. If false, hidden files will be excluded from the artifact.
-
-    include-hidden-files: # optional, default is false
-
-            - name: Download a Build Artifact
-  uses: actions/download-artifact@v7.0.0
-  with:
-    # Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.
-    name: # optional
-    # IDs of the artifacts to download, comma-separated. Either inputs `artifact-ids` or `name` can be used, but not both.
-    artifact-ids: # optional
-    # Destination path. Supports basic tilde expansion. Defaults to $GITHUB_WORKSPACE
-    path: # optional
-    # A glob pattern matching the artifacts that should be downloaded. Ignored if name is specified.
-    pattern: # optional
-    # When multiple artifacts are matched, this changes the behavior of the destination directories. If true, the downloaded artifacts will be in the same directory specified by path. If false, the downloaded artifacts will be extracted into individual named directories within the specified path.
-    merge-multiple: # optional, default is false
-    # The GitHub token used to authenticate with the GitHub API. This is required when downloading artifacts from a different repository or from a different workflow run. If this is not specified, the action will attempt to download artifacts from the current repository and the current workflow run.
-    github-token: # optional
-    # The repository owner and the repository name joined together by "/". If github-token is specified, this is the repository that artifacts will be downloaded from.
-    repository: # optional, default is ${{ github.repository }}
-    # The id of the workflow run where the desired download artifact was uploaded from. If github-token is specified, this is the run that artifacts will be downloaded from.
-    run-id: # optional, default is ${{ github.run_id }}
-          
-          
+      - name: Test with pytest
+        run: |
+          python -m pytest tests/ -v --tb=short


### PR DESCRIPTION
… icon

- python-package-conda.yml: completely rewritten — removed ~80 lines of GitHub Actions marketplace boilerplate pasted outside the jobs block, removed reference to nonexistent environment.yml, replaced conda with pip, scoped flake8 to active code directories, added Python 3.10/3.11/3.12 matrix
- pylint.yml: replaced three column-0 Python heredoc blocks (invalid YAML) with equivalent single-line python -c commands that stay within YAML block scalar indentation; YAML now parses correctly with pyyaml/js-yaml
- Add ♓ Pisces icon footer to both modified workflow files

Agent-Logs-Url: https://github.com/Eaprime1/hodie/sessions/2ca4cea9-6c21-4655-8715-1e8337e9e9c1