### PR TITLE
Add .valox pylint quickwins, telemetry schema, and sample data

### DIFF
--- a/.valox/README.md
+++ b/.valox/README.md
@@ -10,10 +10,17 @@ This folder holds operational lint strategy artifacts for rapid quality wins and
 
 ## Contents
 - `pylint_quickwins.todo.md`: Prioritized tactical TODOs mapped to active pylint diagnostics.
-- `pylint_telemetry.schema.json`: JSON schema for lint event telemetry.
-- `pylint_telemetry.sample.yaml`: Starter telemetry event sample for onboarding.
+- `pylint_telemetry.schema.json`: JSON Schema for the lint event telemetry data model.
+- `pylint_telemetry.sample.yaml`: Starter telemetry event sample for onboarding in YAML form.
+
+Telemetry may be authored in YAML for readability, but schema validation is defined against the
+JSON data model described by `pylint_telemetry.schema.json`. When validating a YAML telemetry
+file, first load or convert it to JSON-equivalent data and then validate that data against the
+schema.
 
 ## Usage
 1. Resolve P0 checklist items first.
 2. Record each lint event/fix into telemetry.
-3. Use recurring trend analysis to reduce repeated classes of warnings.
+3. If the telemetry is stored as YAML, convert or load it as JSON-equivalent data before
+   validating it against `pylint_telemetry.schema.json`.
+4. Use recurring trend analysis to reduce repeated classes of warnings.

--- a/.valox/README.md
+++ b/.valox/README.md
@@ -1,4 +1,4 @@
-# .valox Development Notes
+# 🔍 .valox Development Notes
 
 This folder holds operational lint strategy artifacts for rapid quality wins and iterative lint intelligence.
 
@@ -24,3 +24,9 @@ schema.
 3. If the telemetry is stored as YAML, convert or load it as JSON-equivalent data before
    validating it against `pylint_telemetry.schema.json`.
 4. Use recurring trend analysis to reduce repeated classes of warnings.
+
+---
+
+🛠️ *Work recorded here — lint intelligence built iteratively, one win at a time.*
+
+♓ *∰◊€π¿🌌∞*

--- a/.valox/README.md
+++ b/.valox/README.md
@@ -1,0 +1,19 @@
+# .valox Development Notes
+
+This folder holds operational lint strategy artifacts for rapid quality wins and iterative lint intelligence.
+
+## Key Concepts
+- vincere
+- victoria
+- vici
+- facilis
+
+## Contents
+- `pylint_quickwins.todo.md`: Prioritized tactical TODOs mapped to active pylint diagnostics.
+- `pylint_telemetry.schema.json`: JSON schema for lint event telemetry.
+- `pylint_telemetry.sample.yaml`: Starter telemetry event sample for onboarding.
+
+## Usage
+1. Resolve P0 checklist items first.
+2. Record each lint event/fix into telemetry.
+3. Use recurring trend analysis to reduce repeated classes of warnings.

--- a/.valox/pylint_quickwins.todo.md
+++ b/.valox/pylint_quickwins.todo.md
@@ -38,5 +38,5 @@
 - Default action: delete import
 - Allowed keep case: explicit re-export in `__init__.py` with comment
 
-### W1309
+### C0209 (consider-using-f-string)
 - Align with project formatting rule and apply consistently in touched scope first

--- a/.valox/pylint_quickwins.todo.md
+++ b/.valox/pylint_quickwins.todo.md
@@ -1,0 +1,42 @@
+# Pylint Quick Wins TODO (Vincere · Victoria · Vici · Facilis)
+
+## P0 — Fastest safety/value wins
+- [ ] **W1514**: Add explicit `encoding="utf-8"` to all text `open()` calls in touched files.
+- [ ] **W0611**: Remove unused imports in touched files only.
+- [ ] **C0415**: Move imports to module top unless lazy import is required (document reason inline if kept local).
+
+## P1 — Correctness & signal quality
+- [ ] **W0718**: Replace broad `except Exception` with specific exception classes where known.
+- [ ] **W0718**: If broad catch remains, log context + re-raise or convert to typed domain error with rationale.
+
+## P2 — Style/maintainability debt with guardrails
+- [ ] **W1309**: Normalize string formatting style (prefer consistent f-string/format policy per project rules).
+- [ ] **W06…**: Audit remaining W06xx warnings; resolve by smallest safe code change first, scoped disable second.
+
+## P3 — Policy & lint learning loop
+- [ ] For every pylint disable, require: rule id + short rationale + exit condition for future removal.
+- [ ] Record each warning in `.valox/pylint_telemetry.sample.yaml` (or generated telemetry file).
+- [ ] Add monthly trend check: top 10 recurring rule IDs by path and fix latency.
+
+---
+
+## Rule-specific micro-playbooks
+
+### W1514 (unspecified-encoding)
+- Default action: `open(path, "r", encoding="utf-8")`
+- Exception: binary mode or externally mandated encoding (document it)
+
+### W0718 (broad-exception-caught)
+- Default action: catch known exception types
+- If unknown boundary: broad catch allowed only with telemetry/log context + rationale
+
+### C0415 (import-outside-toplevel)
+- Default action: top-level imports
+- Allowed local import cases: cycle break, optional dependency, startup perf
+
+### W0611 (unused-import)
+- Default action: delete import
+- Allowed keep case: explicit re-export in `__init__.py` with comment
+
+### W1309
+- Align with project formatting rule and apply consistently in touched scope first

--- a/.valox/pylint_quickwins.todo.md
+++ b/.valox/pylint_quickwins.todo.md
@@ -1,4 +1,4 @@
-# Pylint Quick Wins TODO (Vincere · Victoria · Vici · Facilis)
+# 🛠️ Pylint Quick Wins TODO (Vincere · Victoria · Vici · Facilis)
 
 ## P0 — Fastest safety/value wins
 - [ ] **W1514**: Add explicit `encoding="utf-8"` to all text `open()` calls in touched files.
@@ -40,3 +40,9 @@
 
 ### C0209 (consider-using-f-string)
 - Align with project formatting rule and apply consistently in touched scope first
+
+---
+
+🛠️ *Fixes applied here — every resolved item is a victory.*
+
+♓ *∰◊€π¿🌌∞*

--- a/.valox/pylint_quickwins.todo.md
+++ b/.valox/pylint_quickwins.todo.md
@@ -11,7 +11,7 @@
 
 ## P2 — Style/maintainability debt with guardrails
 - [ ] **C0209**: Normalize string formatting style (prefer consistent f-string/format policy per project rules).
-- [ ] **W06…**: Audit remaining W06xx warnings; resolve by smallest safe code change first, scoped disable second.
+- [ ] **W06xx**: Audit remaining W06xx warnings; resolve by smallest safe code change first, scoped disable second.
 
 ## P3 — Policy & lint learning loop
 - [ ] For every pylint disable, require: rule id + short rationale + exit condition for future removal.

--- a/.valox/pylint_quickwins.todo.md
+++ b/.valox/pylint_quickwins.todo.md
@@ -10,7 +10,7 @@
 - [ ] **W0718**: If broad catch remains, log context + re-raise or convert to typed domain error with rationale.
 
 ## P2 — Style/maintainability debt with guardrails
-- [ ] **W1309**: Normalize string formatting style (prefer consistent f-string/format policy per project rules).
+- [ ] **C0209**: Normalize string formatting style (prefer consistent f-string/format policy per project rules).
 - [ ] **W06…**: Audit remaining W06xx warnings; resolve by smallest safe code change first, scoped disable second.
 
 ## P3 — Policy & lint learning loop

--- a/.valox/pylint_telemetry.sample.yaml
+++ b/.valox/pylint_telemetry.sample.yaml
@@ -1,0 +1,29 @@
+meta:
+  project: hodie
+  version: "1.0"
+  concepts: [vincere, victoria, vici, facilis]
+  generated_at: "2026-04-24T00:00:00Z"
+  commit: ""
+  pr_number: 84
+
+events:
+  - rule_id: W1514
+    message: "Using open without explicitly specifying an encoding"
+    path: "crawler_pixel8/cli/test_crawler.py"
+    line: 1
+    symbol: "unspecified-encoding"
+    category: safety
+    severity: medium
+    confidence: high
+    fix_strategy: code_change
+    status: open
+    rationale: "Add encoding='utf-8' for deterministic text I/O."
+    owner: "Copilot"
+    time_to_fix_minutes: 5
+    regression_risk: low
+    mustard_traits:
+      quality: "portability"
+      flavor: "robustness"
+      ingredients: ["open()", "text read/write", "default encoding"]
+      region: "cli"
+      base: "environment variance"

--- a/.valox/pylint_telemetry.sample.yaml
+++ b/.valox/pylint_telemetry.sample.yaml
@@ -1,3 +1,7 @@
+# 🔍 Valox Pylint Telemetry Sample — hodie
+# custom_traits: key/value annotations for classifying lint events by quality dimension,
+# code region, or other project-specific axes. Drives trend analysis and grouping.
+# ♓ ∰◊€π¿🌌∞
 meta:
   project: hodie
   version: "1.0"
@@ -21,9 +25,13 @@ events:
     owner: "Copilot"
     time_to_fix_minutes: 5
     regression_risk: low
-    mustard_traits:
+    custom_traits:
       quality: "portability"
       flavor: "robustness"
       ingredients: ["open()", "text read/write", "default encoding"]
       region: "cli"
       base: "environment variance"
+
+# ---
+# 🛠️ Work recorded here — each event documents a lint issue and its resolution path.
+# ♓ ∰◊€π¿🌌∞

--- a/.valox/pylint_telemetry.schema.json
+++ b/.valox/pylint_telemetry.schema.json
@@ -67,7 +67,8 @@
             "type": "string",
             "enum": ["low", "medium", "high"]
           },
-          "mustard_traits": {
+          "custom_traits": {
+            "description": "Arbitrary key/value annotations for classifying the lint event by quality dimension, code region, or other project-specific axes. Use these to drive trend analysis and group related warnings.",
             "type": "object",
             "properties": {
               "quality": { "type": "string" },

--- a/.valox/pylint_telemetry.schema.json
+++ b/.valox/pylint_telemetry.schema.json
@@ -12,8 +12,7 @@
         "version": { "type": "string" },
         "concepts": {
           "type": "array",
-          "items": { "type": "string" },
-          "default": ["vincere", "victoria", "vici", "facilis"]
+          "items": { "type": "string" }
         },
         "generated_at": { "type": "string", "format": "date-time" },
         "commit": { "type": "string" },

--- a/.valox/pylint_telemetry.schema.json
+++ b/.valox/pylint_telemetry.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Valox Pylint Telemetry",
+  "type": "object",
+  "required": ["meta", "events"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["project", "version", "concepts", "generated_at"],
+      "properties": {
+        "project": { "type": "string" },
+        "version": { "type": "string" },
+        "concepts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["vincere", "victoria", "vici", "facilis"]
+        },
+        "generated_at": { "type": "string", "format": "date-time" },
+        "commit": { "type": "string" },
+        "pr_number": { "type": "integer" }
+      },
+      "additionalProperties": false
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "rule_id",
+          "message",
+          "path",
+          "line",
+          "category",
+          "severity",
+          "fix_strategy",
+          "status"
+        ],
+        "properties": {
+          "rule_id": { "type": "string", "examples": ["W1309", "W1514", "W0718", "C0415", "W0611"] },
+          "message": { "type": "string" },
+          "path": { "type": "string" },
+          "line": { "type": "integer", "minimum": 1 },
+          "symbol": { "type": "string" },
+          "category": {
+            "type": "string",
+            "enum": ["correctness", "safety", "style", "maintainability", "performance", "security"]
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["low", "medium", "high", "critical"]
+          },
+          "confidence": {
+            "type": "string",
+            "enum": ["low", "inference", "high", "certain"]
+          },
+          "fix_strategy": {
+            "type": "string",
+            "enum": ["code_change", "refactor", "disable_scoped", "disable_file", "defer"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["open", "fixed", "accepted_disable", "wont_fix", "deferred"]
+          },
+          "rationale": { "type": "string" },
+          "owner": { "type": "string" },
+          "time_to_fix_minutes": { "type": "number", "minimum": 0 },
+          "regression_risk": {
+            "type": "string",
+            "enum": ["low", "medium", "high"]
+          },
+          "mustard_traits": {
+            "type": "object",
+            "properties": {
+              "quality": { "type": "string" },
+              "flavor": { "type": "string" },
+              "ingredients": { "type": "array", "items": { "type": "string" } },
+              "region": { "type": "string" },
+              "base": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.valox/pylint_telemetry.schema.json
+++ b/.valox/pylint_telemetry.schema.json
@@ -35,7 +35,7 @@
           "status"
         ],
         "properties": {
-          "rule_id": { "type": "string", "examples": ["W1309", "W1514", "W0718", "C0415", "W0611"] },
+          "rule_id": { "type": "string", "examples": ["C0209", "W1514", "W0718", "C0415", "W0611"] },
           "message": { "type": "string" },
           "path": { "type": "string" },
           "line": { "type": "integer", "minimum": 1 },


### PR DESCRIPTION
This pull request introduces a structured approach to managing and tracking pylint linting issues for the project by adding operational documentation, prioritized TODOs, and telemetry artifacts under the `.valox` directory. The changes establish a clear workflow for addressing lint warnings, recording fixes, and analyzing trends to improve code quality iteratively.

Key changes include:

**Linting Strategy & Documentation**
- Added `.valox/README.md` to document the lint strategy concepts, folder contents, and a step-by-step usage guide for addressing lint issues and recording telemetry.
- Introduced `.valox/pylint_quickwins.todo.md`, a prioritized checklist of pylint warnings (with micro-playbooks for common issues) to guide rapid, high-value code improvements.

**Telemetry & Tracking**
- Added `.valox/pylint_telemetry.schema.json`, defining a JSON schema for recording detailed lint event telemetry, including metadata, rule details, fix strategies, and custom traits.
- Provided `.valox/pylint_telemetry.sample.yaml`, a sample telemetry file illustrating how to log and describe a lint issue and its context for onboarding and trend analysis.…opment notes