### PR TITLE
Fix witness regex to reject extra digits and trailing text

### DIFF
--- a/scripts/footer_witness.py
+++ b/scripts/footer_witness.py
@@ -69,8 +69,9 @@ WITNESS_SYMBOL = "∰"
 # Canonical pattern: ∰ <space/tab(s)> YYYYMMDDHHMMSSMS (17 digits)
 # Use horizontal whitespace only so a witness split across lines is not
 # treated as valid when matching against a multi-line footer string.
+# Enforce full-token match: no trailing digits or trailing text.
 WITNESS_PATTERN = re.compile(
-    r"∰[ \t]+(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})"
+    r"∰[ \t]+(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})(?!\d|\S)"
 )
 
 # Number of lines from end of file to consider as "footer"

--- a/scripts/footer_witness.py
+++ b/scripts/footer_witness.py
@@ -69,9 +69,12 @@ WITNESS_SYMBOL = "∰"
 # Canonical pattern: ∰ <space/tab(s)> YYYYMMDDHHMMSSMS (17 digits)
 # Use horizontal whitespace only so a witness split across lines is not
 # treated as valid when matching against a multi-line footer string.
-# Enforce full-token match: no trailing digits or trailing text.
+# Enforce full-token match: after the 17-digit timestamp only optional
+# horizontal whitespace is allowed before end-of-line or end-of-string,
+# so trailing text such as "∰ 20260424024720123 extra" is rejected.
 WITNESS_PATTERN = re.compile(
-    r"∰[ \t]+(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})(?!\d|\S)"
+    r"∰[ \t]+(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})[ \t]*$",
+    re.MULTILINE,
 )
 
 # Number of lines from end of file to consider as "footer"


### PR DESCRIPTION
This pull request makes a targeted improvement to the regular expression used to match witness tokens in the `footer_witness.py` script. The change ensures that only complete witness tokens are matched, preventing partial or invalid matches.

Regular expression accuracy:

* Updated the `WITNESS_PATTERN` regular expression in `footer_witness.py` to require a full-token match, disallowing any trailing digits or non-whitespace text after the witness pattern. This prevents accidental matches of substrings or malformed tokens.