### PR TITLE
Fix witness-check failure and add footer witness guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ hodie/
 
 ---
 
+## Prima Witness footer check (local quick use)
+
+To avoid CI failures from missing witness footers, run the scanner locally before push:
+
+```bash
+python scripts/footer_witness.py --root . --strict
+```
+
+Generate a fresh witness stamp when you need to append one:
+
+```bash
+python scripts/footer_witness.py --stamp
+```
+
+Canonical footer format for new/changed scannable files (`.py`, `.md`, `.txt`, `.rst`):
+
+```text
+∰ YYYYMMDDHHMMSSMS
+```
+
+---
+
 **∰◊€π¿🌌∞**
 
 **∰🛠️♓-salmon_canon**

--- a/crawler_pixel8/cli/main.py
+++ b/crawler_pixel8/cli/main.py
@@ -163,3 +163,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+# ∰ 20260424190238001

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,650 +1,665 @@
 {
-  "last_scan": "20260424025509723",
+  "last_scan": "20260424202838805",
   "known_files": {
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".scripts/sync_hodie.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "CHANGELOG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260424025509723"
+      "last_seen": "20260424202838805"
+    },
+    ".valox/README.md": {
+      "compliant": true,
+      "witness": "∰ 20260424120230871",
+      "last_seen": "20260424202838805"
+    },
+    ".valox/pylint_quickwins.todo.md": {
+      "compliant": true,
+      "witness": "∰ 20260424120230871",
+      "last_seen": "20260424202838805"
+    },
+    "crawler_pixel8/cli/main.py": {
+      "compliant": true,
+      "witness": "∰ 20260424190238001",
+      "last_seen": "20260424202838805"
     }
   }
 }


### PR DESCRIPTION
This pull request introduces documentation and process improvements related to the Prima Witness footer system, along with a new witness stamp added to the `crawler_pixel8/cli/main.py` file. The changes aim to help developers avoid CI failures by ensuring proper witness footers are present.

Documentation and process updates:

* Added a new section to `README.md` with instructions for running the witness footer scanner locally, generating a new witness stamp, and the required canonical footer format for scannable files.

Witness stamp update:

* Appended a fresh Prima Witness footer stamp to the end of `crawler_pixel8/cli/main.py` to comply with the updated process.