### PR TITLE
Revert "fix: prevent gemini-dispatch workflow failures when jobs are skipped"

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -11,7 +11,6 @@ on:
     types: ['opened', 'reopened']
   issue_comment:
     types: ['created']
-  workflow_dispatch: {}
 
 defaults:
   run:
@@ -133,28 +132,4 @@ jobs:
     with:
       additional_context: '${{ needs.dispatch.outputs.additional_context }}'
     secrets: 'inherit'
-
-  conclude:
-    name: 'Conclude'
-    runs-on: 'ubuntu-latest'
-    needs: ['dispatch', 'review', 'triage', 'invoke']
-    if: '!cancelled()'
-    permissions: {}
-    steps:
-      - name: 'Check for upstream failures'
-        env:
-          DISPATCH_RESULT: '${{ needs.dispatch.result }}'
-          REVIEW_RESULT: '${{ needs.review.result }}'
-          TRIAGE_RESULT: '${{ needs.triage.result }}'
-          INVOKE_RESULT: '${{ needs.invoke.result }}'
-        run: |-
-          echo "dispatch=${DISPATCH_RESULT} review=${REVIEW_RESULT} triage=${TRIAGE_RESULT} invoke=${INVOKE_RESULT}"
-          results=("${DISPATCH_RESULT}" "${REVIEW_RESULT}" "${TRIAGE_RESULT}" "${INVOKE_RESULT}")
-          for r in "${results[@]}"; do
-            if [[ "${r}" == "failure" ]]; then
-              echo "::error::Upstream job failed (result=${r})." >&2
-              exit 1
-            fi
-          done
-          echo "All jobs either succeeded or were skipped."
 # ∰🛠️♓-salmon_canon

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -19,7 +19,6 @@ defaults:
 jobs:
   invoke:
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 7
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
This pull request makes several clean-up changes to the GitHub Actions workflow files, primarily by removing unused or redundant configuration sections. The most notable changes are the removal of the `conclude` job from `gemini-dispatch.yml` and the elimination of the `timeout-minutes` setting from the `gemini-invoke.yml` workflow.

**Workflow clean-up and simplification:**

* Removed the `conclude` job from `.github/workflows/gemini-dispatch.yml`, which previously checked for upstream job failures after workflow completion.
* Removed the `workflow_dispatch` trigger from `.github/workflows/gemini-dispatch.yml`, so the workflow can no longer be triggered manually.
* Removed the `timeout-minutes: 7` setting from the `invoke` job in `.github/workflows/gemini-invoke.yml`, so the job will now use the default timeout.Reverts Eaprime1/hodie#106