### PR TITLE
Fix Prima Witness state persistence + branch cleanup script

### DIFF
--- a/.github/workflows/footer-witness.yml
+++ b/.github/workflows/footer-witness.yml
@@ -29,7 +29,7 @@ jobs:
     name: ∰ Prima Witness Check
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -46,13 +46,26 @@ jobs:
         id: witness
         # --strict causes exit 1 when newly introduced files lack witness.
         # The scanner uses the checked-in quepad/state.json on startup when
-        # that file exists in the repository checkout. However, this CI job
-        # does not automatically write updated state back to the repo between
-        # runs, so state only advances when quepad/state.json is committed or
-        # restored from a cache/artifact.
+        # that file exists in the repository checkout. The "Commit refreshed
+        # scan state" step below writes the result back on push events, so
+        # state actually accumulates instead of going stale between manual
+        # refreshes (see issue #149).
         run: |
           python scripts/footer_witness.py --root . --strict
         continue-on-error: true
+
+      - name: Commit refreshed scan state
+        # Only on same-repo push events — no push access on pull_request
+        # (especially from forks), and no reason to commit on every PR run.
+        # quepad/** isn't in this workflow's own path filters, so this can't
+        # trigger an infinite loop; [skip ci] is belt-and-suspenders.
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add quepad/state.json
+          git diff --cached --quiet || git commit -m "quepad: refresh witness scan state [skip ci]"
+          git diff --cached --quiet || git push
 
       - name: Upload quepad reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/footer-witness.yml
+++ b/.github/workflows/footer-witness.yml
@@ -64,8 +64,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add quepad/state.json
-          git diff --cached --quiet || git commit -m "quepad: refresh witness scan state [skip ci]"
-          git diff --cached --quiet || git push
+          if ! git diff --cached --quiet; then
+            git commit -m "quepad: refresh witness scan state [skip ci]"
+            git push
+          fi
 
       - name: Upload quepad reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/sovran-voice.yml
+++ b/.github/workflows/sovran-voice.yml
@@ -30,7 +30,7 @@ jobs:
             // from untrusted PR content, and gemini-review.yml already posts a
             // full AI review on the same event — this stays a quick, factual
             // daily-ledger entry rather than duplicating that).
-            const { data: files } = await github.rest.pulls.listFiles({
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pr.number,

--- a/.github/workflows/sovran-voice.yml
+++ b/.github/workflows/sovran-voice.yml
@@ -23,6 +23,24 @@ jobs:
             const pr = context.payload.pull_request;
             const today = new Date().toISOString().split('T')[0];
             const author = pr.user.login;
+
+            // Real per-PR facts, not a template — pull structured data straight
+            // from the PR/file-list APIs rather than piping PR title/body text
+            // into anything that generates prose (avoids prompt-injection risk
+            // from untrusted PR content, and gemini-review.yml already posts a
+            // full AI review on the same event — this stays a quick, factual
+            // daily-ledger entry rather than duplicating that).
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const areas = [...new Set(files.map(f => f.filename.split('/')[0]))];
+            const areasLine = areas.length
+              ? areas.slice(0, 6).join(', ') + (areas.length > 6 ? `, +${areas.length - 6} more` : '')
+              : '(no files changed)';
+
             const body = [
               '## ⏱ Hodie — The Daily Ledger',
               '',
@@ -31,7 +49,9 @@ jobs:
               '> *Hodie* records what arrives today.',
               '> This work enters the daily flow. What it carries shapes the next cycle.',
               '',
-              `@${author} brings this into the present moment.`,
+              `@${author} brings **"${pr.title}"** into the present moment —`,
+              `${pr.changed_files} file${pr.changed_files === 1 ? '' : 's'} touched (+${pr.additions}/−${pr.deletions}) across ${pr.commits} commit${pr.commits === 1 ? '' : 's'}.`,
+              `Areas: ${areasLine}`,
               '',
               '**From the daily watch:**',
               '- Does this serve the current operational cycle?',

--- a/.journey/BRANCHES_WITH_WORK.md
+++ b/.journey/BRANCHES_WITH_WORK.md
@@ -32,3 +32,4 @@ These branches contain unique commits and need proper review before finalization
 ---
 
 ∰ Documented 20260720
+∰ 20260720051500001

--- a/.journey/BRANCH_FINALIZATION_20260720.md
+++ b/.journey/BRANCH_FINALIZATION_20260720.md
@@ -32,3 +32,4 @@ Binary superposition across time - the journey itself was the purpose.
 
 ---
 ∰ Witnessed 20260720
+∰ 20260720051500000

--- a/.journey/CLEANUP_SPAWN_BRANCHES.sh
+++ b/.journey/CLEANUP_SPAWN_BRANCHES.sh
@@ -8,6 +8,13 @@ echo ""
 echo "The following spawn branches (ahead=0) have been witnessed"
 echo "in commit 58cd6f3 and are ready for deletion:"
 echo ""
+echo "NOTE: 'radix' and '֍hodie֎' were pulled from this list on"
+echo "2026-07-20 — they are NOT spawn branches. radix is the permanent"
+echo "go-between branch (main -> radix -> ֍hodie֎), and ֍hodie֎ is the"
+echo "published branch itself. Both were only 'ahead=0' because they had"
+echo "just been fast-forwarded to main in PR #147, not because they are"
+echo "disposable. Never include them in a spawn-branch cleanup list."
+echo ""
 
 # Spawn branches to delete
 branches=(
@@ -18,9 +25,7 @@ branches=(
   "copilot/fix-code-issues"
   "copilot/improve-setup-scripts-security"
   "feature/crawler-pixel8-adaptation"
-  "radix"
   "shadow/wisp-codex-202604"
-  "֍hodie֎"
 )
 
 echo "Ready to delete ${#branches[@]} branches."

--- a/HODIE.md
+++ b/HODIE.md
@@ -43,6 +43,11 @@ All entities in the UNEXUS ecosystem:
 
 Custos (Java/Coffee Haven) is the host entity of THE hodie.
 Role: guardian, shepherd, husbandry — barista of first contact.
+
+- **Guardian** — nothing enters without being seen.
+- **Shepherd** — nothing that enters is left to find its own way; Custos tends the path from arrival to destination.
+- **Husbandry** — nothing that stays goes uncared-for.
+
 Every arrival is received. Every stream is tended. Every departure is witnessed.
 
 ## Drive Participant Bond
@@ -63,3 +68,4 @@ This is where contrast becomes knowledge.
 ∰ 20260428035509157 — HODIE.md first witness
 Branch: hodie-makeover-2026
 ∰ 20260430033238482
+∰ 20260720061500002 — Custos Compact: glossed guardian/shepherd/husbandry

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,720 +1,720 @@
 {
-  "last_scan": "20260720053000977",
+  "last_scan": "20260720053327906",
   "known_files": {
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".valox/README.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".valox/pylint_quickwins.todo.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "CHANGELOG.md": {
       "compliant": true,
       "witness": "∰ 20260426024622073",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": true,
       "witness": "∰ 20251224000000000",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/cli/main.py": {
       "compliant": true,
       "witness": "∰ 20260427120000000",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".journey/BRANCHES_WITH_WORK.md": {
       "compliant": true,
       "witness": "∰ 20260720051500001",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".journey/BRANCH_FINALIZATION_20260720.md": {
       "compliant": true,
       "witness": "∰ 20260720051500000",
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720053000977"
+      "last_seen": "20260720053327906"
     }
   }
 }

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,720 +1,720 @@
 {
-  "last_scan": "20260720051421031",
+  "last_scan": "20260720053000977",
   "known_files": {
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".valox/README.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".valox/pylint_quickwins.todo.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "CHANGELOG.md": {
       "compliant": true,
       "witness": "∰ 20260426024622073",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": true,
       "witness": "∰ 20251224000000000",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/cli/main.py": {
       "compliant": true,
       "witness": "∰ 20260427120000000",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".journey/BRANCHES_WITH_WORK.md": {
       "compliant": true,
       "witness": "∰ 20260720051500001",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".journey/BRANCH_FINALIZATION_20260720.md": {
       "compliant": true,
       "witness": "∰ 20260720051500000",
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051421031"
+      "last_seen": "20260720053000977"
     }
   }
 }

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,720 +1,720 @@
 {
-  "last_scan": "20260720051137455",
+  "last_scan": "20260720051421031",
   "known_files": {
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".valox/README.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".valox/pylint_quickwins.todo.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "CHANGELOG.md": {
       "compliant": true,
       "witness": "∰ 20260426024622073",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": true,
       "witness": "∰ 20251224000000000",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/cli/main.py": {
       "compliant": true,
       "witness": "∰ 20260427120000000",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".journey/BRANCHES_WITH_WORK.md": {
       "compliant": true,
       "witness": "∰ 20260720051500001",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".journey/BRANCH_FINALIZATION_20260720.md": {
       "compliant": true,
       "witness": "∰ 20260720051500000",
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720051137455"
+      "last_seen": "20260720051421031"
     }
   }
 }

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,854 +1,720 @@
 {
-  "last_scan": "20260504004333974",
-  "last_scan": "20260720011613828",
+  "last_scan": "20260720051137455",
   "known_files": {
-    "docs/FOOTER_WITNESS.md": {
-      "compliant": true,
-      "witness": "∰ 20260424000000000",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "scripts/footer_witness.py": {
-      "compliant": true,
-      "witness": "∰ 20260424000000000",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "tests/test_footer_witness.py": {
-      "compliant": true,
-      "witness": "∰ 20260424000000000",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/CLOUD_MOUNTING_GUIDE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/POWERSHELL_GUIDE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/QUICK_REFERENCE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/RCLONE_QUICK_CONFIG.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/SETUP_INDEX.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/Setting up a home server network across devices - Claude.txt": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/WINDOWS_SETUP_GUIDE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".claude/skills/hodie/SKILL.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".gemini/GEMINI.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".gemini/styleguide.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".locations/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".reminders/DONATION_LINK.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".scripts/FILE_SERVER_GUIDE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".scripts/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".scripts/hodie_log.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".scripts/hodie_zero_point.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-    },
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".scripts/sync_hodie.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260720011613828"
-    },
-    ".streams/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "BRANCH_STRATEGY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "CHANGELOG.md": {
-      "compliant": true,
-      "witness": "∰ 20260426024622073",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "CLAUDE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "INVENTORY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "LAPTOP_SETUP.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "MULTI_CLOUD_SETUP.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "NAVIGO.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "PLEXUS_SYSTEM.md": {
-      "compliant": true,
-      "witness": "∰ 20251224000000000",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "PRIME_2026_DEVELOPMENT_PLAN.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "QUICK_START.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "_TODAY/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/__init__.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/cli/__init__.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/cli/batch_processor.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/cli/crawl_consolidated.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/cli/test_crawler.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/config.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/core/__init__.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/core/content_types.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/core/local_processor.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/core/stream_utils.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/processors/__init__.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/processors/conversation_parser.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/processors/entity_queue_processor.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/processors/one_hertz.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/processors/pattern_extractor.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "mission/BRANCH_STRATEGY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "mission/GEMINI_BRIEF.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "mission/NAVIGO.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "mission/PLEXUS_SYSTEM.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "mission/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/CHARACTER_CREATION_TEMPLATE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/GUARDIAN_TRINITY_INFO.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/RUBRIC_SYSTEM.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/abacusian/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/abacusian/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/domain_consciousness/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/jake/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/microversa/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/microversa/DIALOGUE_EXAMPLES.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/microversa/ORIGIN_STORY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/nano_concepts/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/nano_concepts/RESEARCH.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/one_hertz_collective/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/one_hertz_collective/RESEARCH.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/perdura/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/perdura/DIALOGUE_EXAMPLES.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/perdura/ORIGIN_STORY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/resilia/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/resilia/DIALOGUE_EXAMPLES.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/resilia/ORIGIN_STORY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/substrate_entity/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/substrate_entity/README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/tardigradia/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/tardigradia/ORIGIN_STORY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/unexusi/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/vitara/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/vitara/DIALOGUE_EXAMPLES.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/vitara/ORIGIN_STORY.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/wiki_entity/CHARACTER.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/ENTITY_STATUS.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/GRAVITY_CORE_MISSION.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/GRAVITY_CORE_README.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/READY_TO_COLLAPSE.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/REDUNDANCY_REPORT.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/SESSION_COMPLETE_20251220.md": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/prime_collapse.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/prime_search.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/redundancy_entity_analyzer.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "redundancy_entity/redundancy_ranger_custody.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "tests/__init__.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "tests/conftest.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "tests/test_content_types.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "tests/test_conversation_parser.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "tests/test_pattern_extractor.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "tests/test_processor_chain.py": {
-      "compliant": false,
-      "witness": null,
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".valox/README.md": {
-      "compliant": true,
-      "witness": "∰ 20260424120230871",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    ".valox/pylint_quickwins.todo.md": {
-      "compliant": true,
-      "witness": "∰ 20260424120230871",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
-    },
-    "crawler_pixel8/cli/main.py": {
-      "compliant": true,
-      "witness": "∰ 20260427120000000",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
+    },
+    ".valox/README.md": {
+      "compliant": true,
+      "witness": "∰ 20260424120230871",
+      "last_seen": "20260720051137455"
+    },
+    ".valox/pylint_quickwins.todo.md": {
+      "compliant": true,
+      "witness": "∰ 20260424120230871",
+      "last_seen": "20260720051137455"
+    },
+    "CHANGELOG.md": {
+      "compliant": true,
+      "witness": "∰ 20260426024622073",
+      "last_seen": "20260720051137455"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
+    },
+    "PLEXUS_SYSTEM.md": {
+      "compliant": true,
+      "witness": "∰ 20251224000000000",
+      "last_seen": "20260720051137455"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260504004333974"
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/cli/main.py": {
+      "compliant": true,
+      "witness": "∰ 20260427120000000",
+      "last_seen": "20260720051137455"
+    },
+    "docs/FOOTER_WITNESS.md": {
+      "compliant": true,
+      "witness": "∰ 20260424000000000",
+      "last_seen": "20260720051137455"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260720011613828"
+      "last_seen": "20260720051137455"
+    },
+    "scripts/footer_witness.py": {
+      "compliant": true,
+      "witness": "∰ 20260424000000000",
+      "last_seen": "20260720051137455"
+    },
+    "tests/test_footer_witness.py": {
+      "compliant": true,
+      "witness": "∰ 20260424000000000",
+      "last_seen": "20260720051137455"
+    },
+    ".claude/CLOUD_MOUNTING_GUIDE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".claude/POWERSHELL_GUIDE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".claude/QUICK_REFERENCE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".claude/RCLONE_QUICK_CONFIG.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".claude/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".claude/SETUP_INDEX.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".claude/Setting up a home server network across devices - Claude.txt": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".claude/WINDOWS_SETUP_GUIDE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".claude/skills/hodie/SKILL.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".gemini/GEMINI.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".gemini/styleguide.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".journey/BRANCHES_WITH_WORK.md": {
+      "compliant": true,
+      "witness": "∰ 20260720051500001",
+      "last_seen": "20260720051137455"
+    },
+    ".journey/BRANCH_FINALIZATION_20260720.md": {
+      "compliant": true,
+      "witness": "∰ 20260720051500000",
+      "last_seen": "20260720051137455"
+    },
+    ".locations/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".reminders/DONATION_LINK.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".scripts/FILE_SERVER_GUIDE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".scripts/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".scripts/hodie_log.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".scripts/hodie_zero_point.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    ".streams/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "BRANCH_STRATEGY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "CLAUDE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "INVENTORY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "LAPTOP_SETUP.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "MULTI_CLOUD_SETUP.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "NAVIGO.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "PRIME_2026_DEVELOPMENT_PLAN.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "QUICK_START.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "_TODAY/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/__init__.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/cli/__init__.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/cli/batch_processor.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/cli/crawl_consolidated.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/cli/test_crawler.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/config.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/core/__init__.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/core/content_types.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/core/local_processor.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/core/stream_utils.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/processors/__init__.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/processors/conversation_parser.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/processors/entity_queue_processor.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/processors/one_hertz.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "crawler_pixel8/processors/pattern_extractor.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "mission/BRANCH_STRATEGY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "mission/GEMINI_BRIEF.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "mission/NAVIGO.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "mission/PLEXUS_SYSTEM.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "mission/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/CHARACTER_CREATION_TEMPLATE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/GUARDIAN_TRINITY_INFO.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/RUBRIC_SYSTEM.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/abacusian/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/abacusian/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/domain_consciousness/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/jake/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/microversa/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/microversa/DIALOGUE_EXAMPLES.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/microversa/ORIGIN_STORY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/nano_concepts/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/nano_concepts/RESEARCH.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/one_hertz_collective/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/one_hertz_collective/RESEARCH.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/perdura/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/perdura/DIALOGUE_EXAMPLES.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/perdura/ORIGIN_STORY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/resilia/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/resilia/DIALOGUE_EXAMPLES.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/resilia/ORIGIN_STORY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/substrate_entity/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/substrate_entity/README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/tardigradia/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/tardigradia/ORIGIN_STORY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/unexusi/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/vitara/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/vitara/DIALOGUE_EXAMPLES.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/vitara/ORIGIN_STORY.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/wiki_entity/CHARACTER.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/ENTITY_STATUS.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/GRAVITY_CORE_MISSION.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/GRAVITY_CORE_README.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/READY_TO_COLLAPSE.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/REDUNDANCY_REPORT.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/SESSION_COMPLETE_20251220.md": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/prime_collapse.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/prime_search.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/redundancy_entity_analyzer.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "redundancy_entity/redundancy_ranger_custody.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "tests/__init__.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "tests/conftest.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "tests/test_content_types.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "tests/test_conversation_parser.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "tests/test_pattern_extractor.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
+    },
+    "tests/test_processor_chain.py": {
+      "compliant": false,
+      "witness": null,
+      "last_seen": "20260720051137455"
     }
   }
 }
-# ∰ 20260720020353550  manual @eaprime1
-

--- a/scripts/footer_witness.py
+++ b/scripts/footer_witness.py
@@ -220,7 +220,7 @@ def save_state(state: Dict) -> None:
     """Persist state to quepad/state.json."""
     QUEPAD_DIR.mkdir(exist_ok=True)
     STATE_FILE.write_text(
-        json.dumps(state, indent=2, ensure_ascii=False),
+        json.dumps(state, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary

- **Fixes #149** — `footer-witness.yml` never wrote its scan results back to the repo. Added a "Commit refreshed scan state" step, gated to `push` events only.
- **Fixes `.journey/CLEANUP_SPAWN_BRANCHES.sh`** — pulled `radix` and `֍hodie֎` from the deletion list (they're the permanent go-between and published branches, not spawn branches). Gemini's suggestion to also add `claude/explore-hodie-repo-nNHJo` was checked and skipped — that branch no longer exists on origin.
- **Fixes two malformed witness footers** (`.journey/BRANCH_FINALIZATION_20260720.md`, `.journey/BRANCHES_WITH_WORK.md`) that the state-persistence gap let slip through.
- **Fixes missing trailing newline** in `quepad/state.json` — root-caused to `save_state()` in `footer_witness.py` (Gemini caught it on the generated file; fixed the writer so it doesn't recur on every future scan).
- **Makes `sovran-voice.yml`'s PR comment unique per PR** instead of posting an identical static template every time — now pulls real title/file-count/+−/commit-count/touched-areas from the PR APIs. Deliberately avoided piping PR text into an LLM call (prompt-injection surface on a bot that posts back to a public PR; `gemini-review.yml` already does full AI review on the same event).
- **Glosses the three Custos roles** in `HODIE.md` (guardian/shepherd/husbandry were named but never explained).

## Test plan

- All workflow YAML validated directly (parses clean).
- Witness scanner re-run locally after each content fix — 0 new-missing throughout.
- `sovran-voice.yml`'s new logic hasn't fired live yet (this PR's `opened` event already posted the old static comment before the fix) — will confirm when this PR is marked ready for review, which triggers a fresh `ready_for_review` event.
