### PR TITLE
Add session save point — 2026-07-20

### DIFF
--- a/.eric/SESSION_SAVE_POINT_2026-07-20.md
+++ b/.eric/SESSION_SAVE_POINT_2026-07-20.md
@@ -1,0 +1,36 @@
+# Session Save Point — 2026-07-20
+
+**Purpose**: Everything from this session, condensed so a fresh session (post-compact/clear) can resume cold. This is the third document in the series — read alongside `.eric/HODIE_SYSTEM_AUDIT_2026-07-19.md` (baseline) and `.eric/HODIE_FINALIZATION_JOURNEY_2026-07-19.md` (PR #147 close-out) for full context, but this file alone should be enough to pick up.
+
+## What happened, in order
+
+1. **PR #147** (merged) — baseline audit, fixed `sovran-voice.yml`'s broken YAML, added `notify-repeated-failure.yml` alerting, reviewed all branches identical to `main`, wrote the mission-seed procedure. Fast-forwarded `radix`/`֍hodie֎` to `main`.
+2. **A second Claude session** (not this one — running in parallel, direct-pushed to `main`) did its own overlapping branch-finalization pass, leaving `.journey/` files including a cleanup script that mistakenly listed `radix` and `֍hodie֎` for deletion.
+3. **PR #143** (merged, was already in flight, not mine) — Drive sync MIME-type fix, fresh quepad scan.
+4. **PR #150** (merged) — this session's second PR:
+   - Fixed `.journey/CLEANUP_SPAWN_BRANCHES.sh` to pull `radix`/`֍hodie֎` back out.
+   - **Fixed the real bug behind issue #149** (now closed): `footer-witness.yml` never wrote scan state back to the repo. Added a commit-back step — went through two review-caught bugs first (missing `workflow-failure` label handling was PR #147; here it was a double-checked-diff logic bug that made the push never fire, caught by Copilot) before landing correctly. **Verified live twice**: once via the PR branch, once again via the actual merge to `main` (commit `5633ae3`) — the auto-commit loop works end-to-end now.
+   - Found and fixed a second, deeper cause of the same symptom: the previously-committed `quepad/state.json` had a stray trailing comment after its closing `}`, making it invalid JSON. `load_state()` swallows parse errors silently, so state was likely never being read back correctly even before the CI-persistence gap existed. Fixed by regenerating cleanly (the writer no longer emits anything like that).
+   - Made `sovran-voice.yml`'s PR comment unique per PR (real title/file-stats/areas from the API, not an LLM call — deliberately avoided piping PR text into a prompt given it's a bot that posts back to a public PR, and `gemini-review.yml` already does full AI review on the same event). **Verified live** on both #150 itself and via a manual draft-toggle test.
+   - Glossed the three Custos roles in `HODIE.md` (guardian/shepherd/husbandry were named but never explained).
+   - Closed issues #145, #146 (both were diagnosing the exact `sovran-voice.yml` break this PR fixed).
+5. **Cloned `Eaprime1/custos`** to `/workspace/custos` and **`Eaprime1/radix`** to `/workspace/radix`, both registered in-session. Neither has been touched — pure exploration/access so far, nothing committed or even examined in depth yet.
+
+## Current state (verified moments before writing this)
+
+- `hodie`: `main` is current, clean, at `5633ae3`. **Zero open PRs, zero open issues.**
+- `custos`: cloned, clean, HEAD `6539449`. Untouched.
+- `radix`: cloned, clean, HEAD `2779401` — a real Next.js app + "Radix suites" CI/CD security repo, thematically named after (but organizationally unrelated to) hodie's `radix` branch. Untouched.
+- Branches still sitting on hodie's remote, still blocked from deletion (`git push --delete` 403s from this environment's proxy, no GitHub MCP delete-branch tool exists): the same ~14 stale/inert branches from the last save point, list is unchanged. The fixed `.journey/CLEANUP_SPAWN_BRANCHES.sh` is ready to run locally (mulberry) whenever.
+- Two mission seeds still awaiting a plant/drop decision: `mission/seeds/SEED_cleanup-prs-with-issues.md`, `mission/seeds/SEED_wisp-codex.md` — see `mission/seeds/`.
+- `sync-hodie.yml` still needs GCP credential rotation (outside repo-side fixes) — unrelated to anything touched this session, still the one open infra item from the original baseline audit.
+
+## Ideas forward (unprompted, take or leave)
+
+- **`custos` and `radix` are cloned but idle.** If the intent was "get this figured out" (branch/PR triage help), radix's own CI/CD security workflows and `pr-enhancement-guide.jsx` might be worth a look — but nothing about either repo has been assessed yet. Worth a short scoping pass before diving in, same as hodie got on day one.
+- **The parallel-session collision from step 2** is worth a standing rule, not just a one-off fix: if multiple Claude sessions can direct-push to `main` on the same repo, a `radix`/`֍hodie֎`-style near-miss will happen again. Maybe worth a `PROTECTED_BRANCHES` note somewhere central (`mission/BRANCH_STRATEGY.md`?) that any session — not just a human — checks before generating a cleanup list.
+- **The mission-seed procedure has now caught one real orphaned promise (PR #98) and flagged two never-planted seeds** — it's earned its keep in one day. Worth using it going forward rather than letting this session's own loose ends (the two seeds above) become the next PR #98.
+
+---
+
+∰ 20260720080000000

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,720 +1,720 @@
 {
-  "last_scan": "20260720061404712",
+  "last_scan": "20260720063927738",
   "known_files": {
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".valox/README.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".valox/pylint_quickwins.todo.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "CHANGELOG.md": {
       "compliant": true,
       "witness": "∰ 20260426024622073",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": true,
       "witness": "∰ 20251224000000000",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/cli/main.py": {
       "compliant": true,
       "witness": "∰ 20260427120000000",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".journey/BRANCHES_WITH_WORK.md": {
       "compliant": true,
       "witness": "∰ 20260720051500001",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".journey/BRANCH_FINALIZATION_20260720.md": {
       "compliant": true,
       "witness": "∰ 20260720051500000",
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720061404712"
+      "last_seen": "20260720063927738"
     }
   }
 }


### PR DESCRIPTION
## Summary

Docs-only. Adds `.eric/SESSION_SAVE_POINT_2026-07-20.md`, a condensed resume-point for this session covering:

- PR #147 and PR #150 (both merged) and what they fixed
- Issues #145, #146, #149 (all closed)
- The parallel-session branch-cleanup near-miss (`radix`/`֍hodie֎`) and how it was caught
- `Eaprime1/custos` and `Eaprime1/radix` now cloned into this session, untouched so far
- Current state snapshot (zero open PRs/issues on hodie, branch-deletion still blocked, two mission seeds still awaiting a decision)
- A short list of unprompted next-step ideas

Meant to be read cold by a fresh session after this conversation compacts or clears.

## Test plan

N/A — documentation only, no functional surface. Footer-witness scanner run locally beforehand (0 new-missing); `.eric/` is excluded from the scan path filters anyway.


---
_Generated by [Claude Code](https://claude.ai/code/session_012EBwf1TgCwgtpLjSy4GWJH)_