### PR TITLE
Add triadic entanglement doc: custos/hodie/radix as proton/neutron/electron

### DIFF
--- a/.eric/HODIE_SERIES_CONVERSATION_01_TRANSITION.md
+++ b/.eric/HODIE_SERIES_CONVERSATION_01_TRANSITION.md
@@ -1,0 +1,48 @@
+# Hodie Series — Conversation 1 → Conversation 2 Transition
+
+**This conversation**: Conversation 1 of the hodie series.
+**Purpose**: Close this conversation out as reference-archive material and set up Conversation 2 with nothing lost. Reviewed from three angles before calling it done: the PR's own perspective, the creator's (mine, doing the work) perspective, and the project's perspective.
+
+---
+
+## The arc, condensed
+
+Started from "the workshop's been idling, dust it off." Ended up touching two repos and five merged PRs plus one still open:
+
+1. **PR #147** (hodie, merged) — baseline audit. Found `sync-hodie.yml` failing daily (GCP credential dead) and `sovran-voice.yml` running on invalid YAML. Fixed the latter live, added repeated-failure alerting, wrote the mission-seed procedure.
+2. **A parallel session** pushed its own branch-cleanup pass straight to `main` mid-stream — its deletion list included `radix` and `֍hodie֎`, the two branches just designated permanent. Caught before damage.
+3. **PR #150** (hodie, merged) — fixed the branch-cleanup script, and the *real* bug behind issue #149: `footer-witness.yml` never wrote scan state back to the repo. Copilot caught a logic bug in the first attempt (commit-then-push checked the same diff twice, so the push never fired) — fixed, then verified live three separate times across three branches.
+4. **PR #151** (hodie, merged) — first save point.
+5. **Custos work**: fast-forwarded `֍custos֎` to `main`. Then the big one — `main-to-radix → radix` (custos PR #206, merged): 25 merge conflicts, resolved one by one. 21 were clean supersessions, 1 was a bug in the incoming side (a clobbered code fence), 4 needed manually-restored references to the Five Lakes Valuation System, and 1 was a genuine content fork — two unrelated ideas filed under the same name and timestamp — split into `atelier/ouroboros-wobble.md` and the new `atelier/lexeme-drift.md`.
+6. **PR #153** (hodie, this conversation's last PR) — the triadic entanglement doc: custos=proton (work), hodie=neutron (create), radix=electron (play), with the neutron/else idea tied directly back to the ouroboros-wobble seed from step 5.
+7. **Custos PR #234** (open) — seeded the "bit germ dust" contributor on-ramp idea, responding to the recurring fringe/bot-submission pattern raised while closing out this conversation.
+
+## Confirmed policy, going forward
+
+**Finalize and merge are separate steps, deliberately.** Finalizing (scoring against Correctness/Consistency/Scope discipline/Verification, applying a `finalized` label) is something I do. Merging is not — that's Eric's call, as the third set of eyes after the automated reviews and my own finalize pass. No auto-approve. This was confirmed explicitly this conversation and should hold for Conversation 2 without needing to be re-asked.
+
+## Three-perspective review
+
+**From the PR's perspective**: every PR this conversation carries its own reasoning in its commit messages and description — not just "what changed" but "why," including the bugs found along the way (the double-checked-diff bug, the invalid-JSON trailing comment, the clobbered code fence). A PR reads like an argument for itself, not just a diff. That held up across all six PRs; worth keeping as the bar for Conversation 2.
+
+**From the creator's perspective**: the biggest single win was refusing to blanket-resolve the 25 `main-to-radix`/`radix` conflicts. The instinct to check "is main-to-radix actually newer, or did it just clobber something" caught real content loss (the Five Lakes references) that a mechanical `--theirs` pass would have silently destroyed. The cost was time — this was the slowest single piece of work this conversation. Worth it. The thing I'd do differently: I didn't proactively ask about the two still-open hodie mission seeds (`SEED_cleanup-prs-with-issues.md`, `SEED_wisp-codex.md`) again before this transition — they're still sitting at `SEED`, not `PLANTED` or `DROPPED`, several turns after being flagged. Flagging again below instead of letting them go quiet.
+
+**From the project's perspective**: hodie, custos, and radix are visibly more legible now than at the start of this conversation — two workflows that were quietly broken are fixed and verified live, a 273-commit branch divergence in custos is reconciled, and there's now a written theory (the triadic doc) connecting all three repos' existing self-descriptions instead of leaving them as separate, unconnected pieces of lore. The project didn't just get bug fixes; it got more coherent.
+
+## Carried forward to Conversation 2 (quick wins, tweaks, open items)
+
+- **Two hodie mission seeds still undecided**: `mission/seeds/SEED_cleanup-prs-with-issues.md`, `mission/seeds/SEED_wisp-codex.md`. Plant or drop.
+- **Branch deletion still blocked everywhere** — `git push --delete` 403s from this environment's proxy in both hodie and custos, no GitHub MCP delete-branch tool exists. Hodie has ~9 inert branches ready; custos has 9 more (see custos session notes). All need the GitHub UI or a local push with real credentials.
+- **`sync-hodie.yml` still needs GCP credential rotation** — unrelated to anything fixed this conversation, still the one open infra item from the original baseline audit.
+- **Custos's `radix` is caught up to `main-to-radix` but not to `main` itself** — `main` moved further during this conversation (13 more commits landed while PR #206 was being resolved). Worth another fast-forward-or-merge pass.
+- **Bit germ dust contributor on-ramp** (custos PR #234, open) — idea seeded, generation mechanism and fringe-detection explicitly left unscoped. Needs real design work, not more seeding.
+- **The specific fringe submission and the new Linear bot-shaped submission** Eric mentioned — not enough detail in this conversation to act on either directly. Needs the actual submission(s) pointed at in Conversation 2.
+- **Cross-conversation content gathering** — raised during the triadic-entanglement discussion (mission/TRIADIC_ENTANGLEMENT_CUSTOS_HODIE_RADIX.md's keyword index exists for exactly this) but the actual gathering mechanism (ad-hoc server workflow vs. staging through navigo) is still undecided.
+
+## Archive note
+
+This document, along with `.eric/HODIE_SYSTEM_AUDIT_2026-07-19.md`, `.eric/BRANCH_FINALIZATION_2026-07-19.md`, `.eric/HODIE_FINALIZATION_JOURNEY_2026-07-19.md`, and `.eric/SESSION_SAVE_POINT_2026-07-20.md`, forms the complete continuity record for Conversation 1. A fresh Conversation 2 should be able to start from this file alone and reconstruct everything above without re-reading the others, though they remain the fuller record if needed.
+
+---
+
+∰ 20260721215700000

--- a/mission/TRIADIC_ENTANGLEMENT_CUSTOS_HODIE_RADIX.md
+++ b/mission/TRIADIC_ENTANGLEMENT_CUSTOS_HODIE_RADIX.md
@@ -1,0 +1,80 @@
+# The Triadic Entanglement — Custos, Hodie, Radix
+
+**Status**: Seed — captured, not yet fully worked
+**Origin**: hodie session, 2026-07-20, developed live across several turns
+**Context**: written in the liminal space before Primal launch — this is oriented as seed material for Primal, not a finished framework
+
+---
+
+## The core mapping
+
+Three repos, three particles, three roles:
+
+| Repo | Particle | Domain | Role |
+|---|---|---|---|
+| **Custos** | Proton | Work — physical, tangible | Defines identity/boundary. Has guests — the only one of the three built to face outward (contributor pipeline, bounty/mission system, "barista of first contact"). |
+| **Hodie** | Neutron | Create — spirit, metaphysical | The stabilizing bulk. No charge, no direct outward reaction — present, substantial, does the real building without itself defining the boundary. |
+| **Radix** | Electron | Play — mental, intangible | The one that actually bonds to things outside the atom. Shadow of Origin (see Shadow Edge Note, below). |
+
+This isn't decoration laid over an empty structure — each role names something that's already substantially real in the three repos, described independently, before anyone framed it as a triad.
+
+## Why it isn't just a metaphor
+
+The pipeline implied by the mapping — **custos plans + seeds → hodie builds → custos certifies → radix distributes** — is already close to half-built:
+
+- **Custos plans + seeds, then certifies.** `custos/.github/workflows/finalize-pr.yml`, triggered by `@claude finalize`, already does exactly this: confirms every review thread is resolved, scores the work (Correctness, Consistency, Scope discipline, Verification), and stamps it `finalized`. Custos certifying isn't a new role to invent — it's a workflow already sitting there, mostly unused for this exact purpose.
+- **Hodie builds, finishes, gets witnessed.** Hodie's own identity doc (`HODIE.md`) says it verbatim: "a living workshop — the place where concepts are built, witnessed, and sent into the stream."
+- **Then moves to radix.** Custos's own `branch-tracker/branches.md` already describes radix as "buffer / go-between — working to showpiece... receives from Jacks, routes to main." Radix is already the terminal handoff stage in the real branch topology, not a new role invented for the metaphor.
+
+## Radix as shadow of Origin
+
+Origin does not exist yet as a fourth thing — it's a placeholder, not a repo. The reasoning for radix's position:
+
+- Hodie's `pulvis` (dust) plexus stage is explicitly marked "ORIGIN connection" in hodie's own inventory notes.
+- `HODIE.md`'s Shadow Edge Note: hodie operates "at the pre-black to shadow edge — the edge that attaches to the thing casting the shadow. Not the shadow itself."
+
+If hodie sits at the edge *next to* the shadow, and radix *is* the shadow, Origin is upstream of both — the thing hodie brushes against and radix is cast from. Not yet named, not yet built. Left open on purpose.
+
+## The neutron, and where it leads
+
+Neutron gets a fourth state beyond simple yes/no: **yes, no, other, else** — a binary superposition plus an "else" branch. "Else" was proposed as Nth-radian-wobble-capable — meaning it's not a fixed third option but a *capacity* to deviate by some variable amount before the loop closes.
+
+**This already has a half-built home in the repo.** `atelier/ouroboros-wobble.md` in custos — the file split apart earlier this session into two documents — describes exactly this: "a deliberate imperfection in the loop... no one engages the full Möbius loop without first earning the wobble." The neutron/else idea and the ouroboros-wobble atelier seed are very likely the same concept arrived at from two directions. Worth reconciling, not worth losing.
+
+**Open question, genuinely unresolved**: is Nth an exponent (a magnitude — how *big* the deviation is) or a dimension count (how *many* independent directions "else" can go)? My read: dimension count fits better. An exponent scales magnitude; what's being described sounds like it's about how many axes the "else" space has, not how far along one axis it reaches. Flagged as open, not settled — matches the "pause and take notice" instinct it was raised with.
+
+## Threads flagged as separate, on purpose
+
+Two things came up during this conversation that are related but explicitly **not** part of this doc:
+
+- **The carbon-atom-as-container-structure model** — described as mostly already built elsewhere. Separate development thread.
+- **Pandora as container-for-concepts** — already real in custos (`pandora/README.md`, `pandora/GERM_SCHEMA.md`), already described in its own docs as "a container branch for cross-conversation germs" (germ = seed). The container-for-seeds idea isn't hypothetical; something with that exact job already exists, underdeveloped. Worth building on rather than duplicating.
+
+Also named but not yet developed in this pass: quark-gluon-quark structure, convergence and diaspora, proton tunneling. Listed here as markers for later, not expanded.
+
+## Gathering content across conversations
+
+The theory here connects to a large amount of prior conversation that isn't in this session's context. Two proposed approaches, both left open rather than decided:
+
+1. **An ad-hoc workflow run by you as the server** — building the doc/theory up from your own steps, session by session, rather than a single automated ingestion.
+2. **Simpler**: stage content toward navigo or other channels when there isn't a dedicated one yet, so nothing sits stranded waiting for infrastructure. Easy to go back and adjust — the point is staying in-process, not getting it right the first time.
+
+Both are compatible with the mission-seed procedure already written in this repo (`mission/MISSION_SEED_PROCEDURE.md`) — this whole document is arguably a mission seed itself, just a large one.
+
+### Keyword index (for cross-referencing against older conversations)
+
+A flat list of the significant terms that came up while this was being worked out, meant as search anchors rather than a glossary:
+
+proton, neutron, electron, nucleus, strong nuclear force, weak force, beta decay, binding energy, quantum energy levels, Pauli exclusion, quark, gluon, convergence, diaspora, proton tunneling, Nth-radian wobble, ouroboros, lexeme drift, Origin, shadow edge, pulvis, radix (seed / root beneath the root), custos (guardian, shepherd, husbandry), hodie (living workshop, pinnacle), finalize-pr certification, prima-clock, moav carriers, witness, atelier (nursery), pandora (container / germs), five lakes valuation, carbon atom model, triadic entanglement, binary superposition, else-branch, degrees of freedom, natural order math, universal translator, harmony spectrum, discord-as-data, braille stream, Primal, tabularium.
+
+## The orchestra image
+
+Raised near the end of this conversation, kept as-is rather than flattened into something more technical: trillions of data streams, in a system where they *stay* while the work happens elsewhere, behaving like a harmony spectrum rather than a flat dataset — discords are not noise but data with a past, present, and future folding into the harmony. A massive stream orchestra, every instrument with its own voice. Named as a direction, not a spec.
+
+## What this doc is for
+
+Named directly: "the seed for Primal." Written during the pause before Primal launch, not as a finished theory but as the seed of one — something with enough structure that the next pass (by you, by a future session, by whichever repo picks it up) doesn't have to re-derive it from scratch.
+
+---
+
+∰ 20260720100000000

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,725 +1,725 @@
 {
-  "last_scan": "20260721031214986",
+  "last_scan": "20260721031241378",
   "known_files": {
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".valox/README.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".valox/pylint_quickwins.todo.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "CHANGELOG.md": {
       "compliant": true,
       "witness": "∰ 20260426024622073",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": true,
       "witness": "∰ 20251224000000000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/cli/main.py": {
       "compliant": true,
       "witness": "∰ 20260427120000000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".journey/BRANCHES_WITH_WORK.md": {
       "compliant": true,
       "witness": "∰ 20260720051500001",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".journey/BRANCH_FINALIZATION_20260720.md": {
       "compliant": true,
       "witness": "∰ 20260720051500000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     },
     "mission/TRIADIC_ENTANGLEMENT_CUSTOS_HODIE_RADIX.md": {
       "compliant": true,
       "witness": "∰ 20260720100000000",
-      "last_seen": "20260721031214986"
+      "last_seen": "20260721031241378"
     }
   }
 }

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,725 +1,725 @@
 {
-  "last_scan": "20260721031241378",
+  "last_scan": "20260721205518472",
   "known_files": {
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".valox/README.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".valox/pylint_quickwins.todo.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "CHANGELOG.md": {
       "compliant": true,
       "witness": "∰ 20260426024622073",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": true,
       "witness": "∰ 20251224000000000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/cli/main.py": {
       "compliant": true,
       "witness": "∰ 20260427120000000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".journey/BRANCHES_WITH_WORK.md": {
       "compliant": true,
       "witness": "∰ 20260720051500001",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".journey/BRANCH_FINALIZATION_20260720.md": {
       "compliant": true,
       "witness": "∰ 20260720051500000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     },
     "mission/TRIADIC_ENTANGLEMENT_CUSTOS_HODIE_RADIX.md": {
       "compliant": true,
       "witness": "∰ 20260720100000000",
-      "last_seen": "20260721031241378"
+      "last_seen": "20260721205518472"
     }
   }
 }

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,720 +1,725 @@
 {
-  "last_scan": "20260720064902775",
+  "last_scan": "20260721031214986",
   "known_files": {
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".valox/README.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".valox/pylint_quickwins.todo.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "CHANGELOG.md": {
       "compliant": true,
       "witness": "∰ 20260426024622073",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": true,
       "witness": "∰ 20251224000000000",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/cli/main.py": {
       "compliant": true,
       "witness": "∰ 20260427120000000",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".journey/BRANCHES_WITH_WORK.md": {
       "compliant": true,
       "witness": "∰ 20260720051500001",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".journey/BRANCH_FINALIZATION_20260720.md": {
       "compliant": true,
       "witness": "∰ 20260720051500000",
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260720064902775"
+      "last_seen": "20260721031214986"
+    },
+    "mission/TRIADIC_ENTANGLEMENT_CUSTOS_HODIE_RADIX.md": {
+      "compliant": true,
+      "witness": "∰ 20260720100000000",
+      "last_seen": "20260721031214986"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds `mission/TRIADIC_ENTANGLEMENT_CUSTOS_HODIE_RADIX.md` — the theory developed live across this session's conversation, written down as requested. Captures:

- The core mapping: custos=proton (work), hodie=neutron (create), radix=electron (play)
- Why it's not just a metaphor — the plan/seed → build → certify → distribute pipeline it implies is already substantially real across the three repos (custos's `finalize-pr.yml`, hodie's own identity doc, radix's branch-tracker description)
- The neutron's yes/no/other/else idea, tied directly to `atelier/ouroboros-wobble.md` in custos (the file this session split apart earlier)
- Two explicitly separate threads (carbon-atom model, pandora-as-container) flagged so they don't get conflated with this doc
- A keyword index for cross-referencing against older conversations
- Framed as seed material for Primal, per how the conversation named it

Status marked `Seed — captured, not yet fully worked` at the top, since several pieces (Nth as exponent vs. dimension count, quark-gluon-quark, convergence/diaspora, proton tunneling) are explicitly left open rather than resolved.

## Test plan

Docs only. Footer-witness scanner run locally — 0 new-missing.


---
_Generated by [Claude Code](https://claude.ai/code/session_012EBwf1TgCwgtpLjSy4GWJH)_