### PR TITLE
fix: resolve Codacy issues in hodie_log.py and hodie_zero_point.py

### DIFF
--- a/.scripts/hodie_log.py
+++ b/.scripts/hodie_log.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-hodie_log.py — HODIE session log reader, reporter, and checklist builder.
+"""hodie_log.py — HODIE session log reader, reporter, and checklist builder.
 
 Every operation that touches HODIE can log a structured JSON entry to
 _TODAY/daily/session.log. This script reads that log and produces:
@@ -18,7 +17,6 @@ Usage:
 
 import argparse
 import json
-import sys
 import time
 from collections import defaultdict
 from datetime import date, datetime
@@ -75,102 +73,116 @@ def append_log(log_path: Path, entry: dict) -> None:
 # Report
 # ---------------------------------------------------------------------------
 
+_SUMMARIES = {
+    "zero_point": lambda e: f"Zero-point '{e.get('zero_point', '?')}' from {Path(e.get('document', '')).name}",
+    "migration": lambda e: f"Migrated: {e.get('source', '?')} → {e.get('destination', '?')}",
+    "intake": lambda e: f"Intake: {e.get('file', '?')} → {e.get('plexus_stage', '?')}",
+    "note": lambda e: e.get("text", "")[:80],
+}
+
+
+def _summarize_entry(entry: dict) -> str:
+    op = entry.get("operation", "note")
+    handler = _SUMMARIES.get(op)
+    if handler:
+        return handler(entry)
+    return json.dumps({k: v for k, v in entry.items() if k not in ("timestamp", "operation")})[:80]
+
+
+def _format_op_section(op: str, items: list[dict]) -> list[str]:
+    plexus = PLEXUS_HINTS.get(op, "simplex")
+    lines = [
+        f"## {op.replace('_', ' ').title()} ({len(items)})",
+        f"*Suggested plexus stage: {plexus}*",
+    ]
+    for item in items[-5:]:
+        ts = item.get("timestamp", "")[:19].replace("T", " ")
+        lines.append(f"- `{ts}` {_summarize_entry(item)}")
+    lines.append("")
+    return lines
+
+
 def render_report(entries: list[dict], target_date: str) -> str:
     if not entries:
         return f"No log entries for {target_date}.\n"
-
-    by_op = defaultdict(list)
+    by_op: defaultdict[str, list] = defaultdict(list)
     for e in entries:
         by_op[e.get("operation", "unknown")].append(e)
-
     lines = [
         f"# HODIE Session Report — {target_date}",
         f"**Entries**: {len(entries)}  |  **Operations**: {len(by_op)}",
         "",
     ]
-
     for op, items in sorted(by_op.items()):
-        lines.append(f"## {op.replace('_', ' ').title()} ({len(items)})")
-        plexus = PLEXUS_HINTS.get(op, "simplex")
-        lines.append(f"*Suggested plexus stage: {plexus}*")
-        for item in items[-5:]:  # last 5 per operation type
-            ts = item.get("timestamp", "")[:19].replace("T", " ")
-            summary = _summarize_entry(item)
-            lines.append(f"- `{ts}` {summary}")
-        lines.append("")
-
+        lines.extend(_format_op_section(op, items))
     return "\n".join(lines)
-
-
-def _summarize_entry(entry: dict) -> str:
-    op = entry.get("operation", "note")
-    if op == "zero_point":
-        zp = entry.get("zero_point", "?")
-        doc = Path(entry.get("document", "")).name
-        return f"Zero-point '{zp}' from {doc}"
-    if op == "migration":
-        return f"Migrated: {entry.get('source', '?')} → {entry.get('destination', '?')}"
-    if op == "intake":
-        return f"Intake: {entry.get('file', '?')} → {entry.get('plexus_stage', '?')}"
-    if op == "note":
-        return entry.get("text", "")[:80]
-    return json.dumps({k: v for k, v in entry.items() if k not in ("timestamp", "operation")})[:80]
 
 # ---------------------------------------------------------------------------
 # Checklist builder
 # ---------------------------------------------------------------------------
 
-def build_checklist(entries: list[dict]) -> str:
-    """
-    Build a TODO checklist from log entries.
-    Anything with status='open', 'pending', or no status gets a checkbox.
-    Completed items get a checked box.
-    """
-    lines = ["# HODIE Checklist — Auto-generated", ""]
+_STANDARD_CHECKLIST = [
+    "- [ ] [simplex] Check _TODAY/inbox/ for new arrivals",
+    "- [ ] [duplex] Run redundancy scan on new content",
+    "- [ ] [triplex] Route processed content to plexus stages",
+    "- [ ] [quadroplex] Review open PRs and AI review comments",
+    "- [ ] [simplex] Write session note to _TODAY/daily/",
+]
 
-    open_items = []
-    done_items = []
 
+def _classify_entries(entries: list[dict]) -> tuple[list[str], list[str]]:
+    """Separate log entries into open and done checklist items."""
+    open_items: list[str] = []
+    done_items: list[str] = []
     for entry in entries:
         status = entry.get("status", "")
         op = entry.get("operation", "")
         summary = _summarize_entry(entry)
-
-        if status == "complete" or status == "done":
+        if status in ("complete", "done"):
             done_items.append(f"- [x] {summary}")
         elif op in ("zero_point", "migration", "intake", "pr_review"):
-            # These are completable actions
             plexus = PLEXUS_HINTS.get(op, "simplex")
             open_items.append(f"- [ ] [{plexus}] {summary}")
+    return open_items, done_items
 
-    # Add standard recurring HODIE checklist items
-    standard = [
-        "- [ ] [simplex] Check _TODAY/inbox/ for new arrivals",
-        "- [ ] [duplex] Run redundancy scan on new content",
-        "- [ ] [triplex] Route processed content to plexus stages",
-        "- [ ] [quadroplex] Review open PRs and AI review comments",
-        "- [ ] [simplex] Write session note to _TODAY/daily/",
-    ]
 
+def build_checklist(entries: list[dict]) -> str:
+    """Build a TODO checklist from log entries.
+
+    Anything with status='open', 'pending', or no status gets a checkbox.
+    Completed items get a checked box.
+    """
+    open_items, done_items = _classify_entries(entries)
+    lines = ["# HODIE Checklist — Auto-generated", ""]
     if open_items:
-        lines.append("## Open")
-        lines.extend(open_items)
-        lines.append("")
-
-    lines.append("## Standard (One Hertz)")
-    lines.extend(standard)
-    lines.append("")
-
+        lines += ["## Open", *open_items, ""]
+    lines += ["## Standard (One Hertz)", *_STANDARD_CHECKLIST, ""]
     if done_items:
-        lines.append("## Done")
-        lines.extend(done_items)
-        lines.append("")
-
+        lines += ["## Done", *done_items, ""]
     return "\n".join(lines)
 
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
+def _watch_log(log_path: Path) -> None:
+    """Tail the log file, printing new entries as they arrive."""
+    print(f"Watching {log_path} (Ctrl+C to stop)...")
+    last_size = 0
+    while True:
+        try:
+            if log_path.exists():
+                current_size = log_path.stat().st_size
+                if current_size > last_size:
+                    entries = read_log(log_path)
+                    if entries:
+                        ts = entries[-1].get("timestamp", "")[:19]
+                        print(f"[{ts}] {_summarize_entry(entries[-1])}")
+                    last_size = current_size
+            time.sleep(2)
+        except KeyboardInterrupt:
+            break
+
 
 def main():
     parser = argparse.ArgumentParser(description="HODIE session log reader and checklist builder")
@@ -183,41 +195,21 @@ def main():
     log_path = log_file_for(args.date)
 
     if args.append:
-        entry = {
+        append_log(log_path, {
             "timestamp": datetime.now().isoformat(),
             "operation": "note",
             "text": args.append,
             "status": "open",
-        }
-        append_log(log_path, entry)
+        })
         print(f"✓ Note logged: {args.append}")
         return
 
     if args.watch:
-        print(f"Watching {log_path} (Ctrl+C to stop)...")
-        last_size = 0
-        while True:
-            try:
-                if log_path.exists():
-                    current_size = log_path.stat().st_size
-                    if current_size > last_size:
-                        entries = read_log(log_path)
-                        if entries:
-                            newest = entries[-1]
-                            ts = newest.get("timestamp", "")[:19]
-                            print(f"[{ts}] {_summarize_entry(newest)}")
-                        last_size = current_size
-                time.sleep(2)
-            except KeyboardInterrupt:
-                break
+        _watch_log(log_path)
         return
 
     entries = read_log(log_path)
-
-    if args.checklist:
-        print(build_checklist(entries))
-    else:
-        print(render_report(entries, args.date))
+    print(build_checklist(entries) if args.checklist else render_report(entries, args.date))
 
 
 if __name__ == "__main__":

--- a/.scripts/hodie_zero_point.py
+++ b/.scripts/hodie_zero_point.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-hodie_zero_point.py — Find the zero-point lexeme of a document and search Perplexity.
+"""hodie_zero_point.py — Find the zero-point lexeme of a document and search Perplexity.
 
 The zero-point lexeme is the single term that anchors a document's meaning —
 remove it and the document loses coherence. This script:
@@ -18,7 +17,6 @@ Usage:
 
 import argparse
 import json
-import logging
 import math
 import os
 import re
@@ -26,6 +24,11 @@ import sys
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    requests = None  # type: ignore[assignment]
 
 # ---------------------------------------------------------------------------
 # Config
@@ -56,9 +59,19 @@ def extract_terms(text: str) -> list[str]:
     return [t for t in tokens if t not in STOPWORDS and not t.isdigit()]
 
 
+def _score_term(term: str, tf: float, total: int, count: int,
+                header_terms: set, early_terms: set) -> float:
+    """Compute weighted TF-IDF score for a single term."""
+    score = tf * math.log(total / count + 1)
+    if term in header_terms:
+        score *= 3.0
+    if term in early_terms:
+        score *= 1.5
+    return score
+
+
 def score_terms(text: str, top_n: int = 5) -> list[tuple[str, float]]:
-    """
-    Score terms by: frequency × title_boost × early_position_weight
+    """Score terms by frequency × title_boost × early_position_weight.
 
     Title/header terms score 3x — they're declared anchors.
     Terms in first 20% of document score 1.5x — authors front-load key concepts.
@@ -67,36 +80,22 @@ def score_terms(text: str, top_n: int = 5) -> list[tuple[str, float]]:
     lines = text.split('\n')
     total_chars = len(text)
 
-    # Collect header terms (markdown h1-h3)
     header_terms: set[str] = set()
     for line in lines:
         if re.match(r'^#{1,3}\s+', line):
             header_terms.update(extract_terms(line))
 
-    # Split into early (first 20%) and rest
     split_point = max(1, total_chars // 5)
-    early_text = text[:split_point]
-    early_terms = set(extract_terms(early_text))
+    early_terms = set(extract_terms(text[:split_point]))
 
-    # All terms
-    all_terms = extract_terms(text)
-    freq = Counter(all_terms)
+    freq = Counter(extract_terms(text))
     total = sum(freq.values()) or 1
 
-    scores: dict[str, float] = {}
-    for term, count in freq.items():
-        tf = count / total
-        # IDF-style: penalize very common terms, boost rarer ones
-        idf = math.log(total / count + 1)
-        score = tf * idf
-        if term in header_terms:
-            score *= 3.0
-        if term in early_terms:
-            score *= 1.5
-        scores[term] = score
-
-    ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
-    return ranked[:top_n]
+    scores = {
+        term: _score_term(term, count / total, total, count, header_terms, early_terms)
+        for term, count in freq.items()
+    }
+    return sorted(scores.items(), key=lambda x: x[1], reverse=True)[:top_n]
 
 
 def find_zero_point(file_path: Path, top_n: int = 1) -> list[tuple[str, float]]:
@@ -111,23 +110,22 @@ def find_zero_point(file_path: Path, top_n: int = 1) -> list[tuple[str, float]]:
 
 def query_perplexity(lexeme: str, context: str = "") -> dict:
     """Query Perplexity API for the zero-point lexeme."""
-    try:
-        import requests
-    except ImportError:
+    if requests is None:
         return {"error": "requests not installed — run: pip install requests"}
 
     api_key = os.environ.get("PERPLEXITY_API_KEY")
     if not api_key:
         return {"error": "PERPLEXITY_API_KEY not set in environment"}
 
-    prompt = f"Explain the concept '{lexeme}' in the context of: {context}" if context else \
-             f"Explain '{lexeme}': its origin, applications, and conceptual significance."
-
+    prompt = (
+        f"Explain the concept '{lexeme}' in the context of: {context}" if context
+        else f"Explain '{lexeme}': its origin, applications, and conceptual significance."
+    )
     payload = {
         "model": "sonar",
         "messages": [
             {"role": "system", "content": "Be concise. Focus on conceptual significance and connections."},
-            {"role": "user", "content": prompt}
+            {"role": "user", "content": prompt},
         ],
         "max_tokens": 400,
     }
@@ -146,7 +144,7 @@ def query_perplexity(lexeme: str, context: str = "") -> dict:
             "response": data["choices"][0]["message"]["content"],
             "citations": data.get("citations", []),
         }
-    except Exception as e:
+    except (requests.RequestException, KeyError, ValueError) as e:
         return {"error": str(e)}
 
 
@@ -165,6 +163,20 @@ def log_to_session(entry: dict) -> None:
 # CLI
 # ---------------------------------------------------------------------------
 
+def _print_perplexity_result(zero_lexeme: str, context: str) -> dict:
+    """Query Perplexity and print the result; return the perplexity payload."""
+    print(f"\n▶ Querying Perplexity for: '{zero_lexeme}'")
+    print("─" * 50)
+    perp = query_perplexity(zero_lexeme, context=context)
+    if "error" in perp:
+        print(f"  Perplexity error: {perp['error']}")
+    else:
+        print(f"\n{perp['response']}\n")
+        for c in perp.get("citations", []):
+            print(f"  - {c}")
+    return perp
+
+
 def main():
     parser = argparse.ArgumentParser(description="Find zero-point lexeme and search Perplexity")
     parser.add_argument("document", help="Path to document file")
@@ -182,12 +194,11 @@ def main():
     print("─" * 50)
 
     ranked = find_zero_point(doc_path, top_n=args.top)
-
     for rank, (lexeme, score) in enumerate(ranked, 1):
         print(f"  #{rank}: '{lexeme}'  (score: {score:.4f})")
 
     zero_lexeme = ranked[0][0] if ranked else None
-    result = {
+    result: dict = {
         "timestamp": datetime.now().isoformat(),
         "operation": "zero_point",
         "document": str(doc_path),
@@ -196,18 +207,7 @@ def main():
     }
 
     if zero_lexeme and not args.no_perplexity:
-        print(f"\n▶ Querying Perplexity for: '{zero_lexeme}'")
-        print("─" * 50)
-        perp = query_perplexity(zero_lexeme, context=args.context)
-        if "error" in perp:
-            print(f"  Perplexity error: {perp['error']}")
-        else:
-            print(f"\n{perp['response']}\n")
-            if perp.get("citations"):
-                print("Citations:")
-                for c in perp["citations"]:
-                    print(f"  - {c}")
-        result["perplexity"] = perp
+        result["perplexity"] = _print_perplexity_result(zero_lexeme, args.context)
 
     log_to_session(result)
     print(f"\n✓ Logged to {LOG_FILE}")

--- a/quepad/state.json
+++ b/quepad/state.json
@@ -1,740 +1,740 @@
 {
-  "last_scan": "20260724065952620",
+  "last_scan": "20260728075137941",
   "known_files": {
     ".scripts/sync_hodie.py": {
       "compliant": true,
       "witness": "∰ 20260504003725277",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".sovran/identity.md": {
       "compliant": true,
       "witness": "∰ 20260615083500000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".valox/README.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".valox/pylint_quickwins.todo.md": {
       "compliant": true,
       "witness": "∰ 20260424120230871",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "CHANGELOG.md": {
       "compliant": true,
       "witness": "∰ 20260427000000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "HODIE.md": {
       "compliant": true,
       "witness": "∰ 20260430033238482",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "PLEXUS_SYSTEM.md": {
       "compliant": true,
       "witness": "∰ 20251224000000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "SECURITY.md": {
       "compliant": true,
       "witness": "∰ 20260426000000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "_TODAY/inbox/CONVERGENCE_202604260033.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "_TODAY/inbox/SESSION_COMMIT_202604270020.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "_TODAY/inbox/arekhe_wisp_codex_202604261318.md": {
       "compliant": true,
       "witness": "∰ 20260428031846559",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/cli/main.py": {
       "compliant": true,
       "witness": "∰ 20260427120000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "docs/FOOTER_WITNESS.md": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/MISSION_SEED_PROCEDURE.md": {
       "compliant": true,
       "witness": "∰ 20260719000000002",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/seeds/SEED_cleanup-prs-with-issues.md": {
       "compliant": true,
       "witness": "∰ 20260719000000003",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/seeds/SEED_wisp-codex.md": {
       "compliant": true,
       "witness": "∰ 20260719000000004",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "scripts/footer_witness.py": {
       "compliant": true,
       "witness": "∰⏱🃏 20260724120000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "tests/test_footer_witness.py": {
       "compliant": true,
       "witness": "∰ 20260424000000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/CLOUD_MOUNTING_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/POWERSHELL_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/QUICK_REFERENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/RCLONE_QUICK_CONFIG.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/SETUP_INDEX.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/Setting up a home server network across devices - Claude.txt": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/WINDOWS_SETUP_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".claude/skills/hodie/SKILL.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".gemini/GEMINI.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".gemini/styleguide.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".journey/BRANCHES_WITH_WORK.md": {
       "compliant": true,
       "witness": "∰ 20260720051500001",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".journey/BRANCH_FINALIZATION_20260720.md": {
       "compliant": true,
       "witness": "∰ 20260720051500000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".locations/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".reminders/DONATION_LINK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".scripts/FILE_SERVER_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".scripts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".scripts/hodie_log.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".scripts/hodie_zero_point.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     ".streams/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "CLAUDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "CRAWLER_DEVELOPMENT_SESSION_20260104.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "CRAWLER_PIXEL8_ADAPTATION_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "INVENTORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "LAPTOP_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "MULTI_CLOUD_SETUP.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "QUICK_START.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "_TODAY/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/cli/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/cli/batch_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/cli/crawl_consolidated.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/cli/test_crawler.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/config.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/core/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/core/content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/core/local_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/core/stream_utils.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/processors/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/processors/conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/processors/entity_queue_processor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/processors/one_hertz.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "crawler_pixel8/processors/pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/BRANCH_STRATEGY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/GEMINI_BRIEF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/NAVIGO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/PLEXUS_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/PRIME_2026_DEVELOPMENT_PLAN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/CHARACTER_CREATION_TEMPLATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/CHARACTER_DEVELOPMENT_UPDATE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/EMOTIONAL_UNDERTONE_GUIDE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/ENTITY_DEVELOPMENT_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/ENTITY_DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/GUARDIAN_REVIEW_AUTOMATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/GUARDIAN_TRINITY_INFO.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/PERSPECTIVE_GUARDIANS_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/PERSPECTIVE_GUARDIANS_QUICK_REF.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/PIXEL_SUBSTRATE_COORDINATION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/QUANTUM_ENTITY_ORIGIN_STORIES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/RUBRIC_SYSTEM.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/SESSION_20251227_CHARACTER_EMERGENCE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/STRATEGIC_ENDURANCE_PATTERN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/abacusian/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/abacusian/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/domain_consciousness/CORE_PHILOSOPHY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/domain_consciousness/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/jake/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/microversa/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/microversa/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/microversa/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/nano_concepts/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/nano_concepts/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/one_hertz_collective/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/one_hertz_collective/RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/perdura/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/perdura/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/perdura/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/pixel_entity/PIXEL_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/resilia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/resilia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/resilia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123 (1).md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/seventh_pinnacle/The_Seventh_Pinnacle_Complete_Framework_20251123.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/substrate_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/substrate_entity/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/substrate_entity/SUBSTRATE_ENTITY_FRAMEWORK.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/tardigradia/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/tardigradia/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/tardigradia/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/unexusi/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/unexusi/UNEXUSI_STATE_ANALYSIS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/vitara/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/vitara/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/vitara/ORIGIN_STORY.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/wiki_entity/API_PROOF_OF_CONCEPT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/wiki_entity/CHARACTER.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/wiki_entity/DIALOGUE_EXAMPLES.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "quanta/wiki_entity/WIKIPEDIA_STRUCTURE_RESEARCH.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/CUSTODY_OPERATIONS_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/ENTITY_STATUS.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/GRAVITY_CONSORTIUM_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/GRAVITY_CORE_MISSION.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/GRAVITY_CORE_README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/GRAVITY_REPO_ARCHITECTURE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/PRIME_COLLAPSE_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/READY_TO_COLLAPSE.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/REDUNDANCY_RANGER_DESIGN.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/REDUNDANCY_REPORT.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/SESSION_COMPLETE_20251220.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/prime_collapse.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/prime_search.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/redundancy_entity_analyzer.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "redundancy_entity/redundancy_ranger_custody.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "tests/__init__.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "tests/conftest.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "tests/test_content_types.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "tests/test_conversation_parser.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "tests/test_pattern_extractor.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "tests/test_processor_chain.py": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "mission/TRIADIC_ENTANGLEMENT_CUSTOS_HODIE_RADIX.md": {
       "compliant": true,
       "witness": "∰ 20260720100000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "pr-journeys/README.md": {
       "compliant": false,
       "witness": null,
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "pr-journeys/202607_PR155_fix-remove-mention-from-sovran-voice-fix.md": {
       "compliant": true,
       "witness": "∰⏱🃏 20260724054842000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     },
     "scripts/check_workflow_injection.py": {
       "compliant": true,
       "witness": "∰⏱🃏 20260724120000000",
-      "last_seen": "20260724065952620"
+      "last_seen": "20260728075137941"
     }
   }
 }


### PR DESCRIPTION
Addresses all Codacy warnings and notices flagged in `.scripts/hodie_log.py` and `.scripts/hodie_zero_point.py`.

## hodie_log.py

| Issue | Fix |
|-------|-----|
| D212 — docstring summary not on first line | Moved to first line |
| F401 — `import sys` unused | Removed |
| D205 — missing blank line between summary and description | Added in `build_checklist` docstring |
| L139 — `status == "complete" or status == "done"` | Changed to `status in ("complete", "done")` |
| `_summarize_entry` complexity 7 (limit 5) | Replaced if-chain with `_SUMMARIES` dispatch dict; complexity drops to 2 |
| `render_report` 21 lines (limit 20) | Extracted `_format_op_section` helper; method now ~10 lines |
| `build_checklist` 37 lines / complexity 7 | Extracted `_classify_entries` helper and module-level `_STANDARD_CHECKLIST` constant |
| `main` 41 lines / complexity 9 / 6 nested blocks | Extracted `_watch_log` helper; nesting reduced to 3 |

## hodie_zero_point.py

| Issue | Fix |
|-------|-----|
| D212 — docstring summary not on first line | Moved to first line |
| F401 — `import logging` unused | Removed |
| D415 — `score_terms` docstring first line doesn't end with `.` | Added period |
| Import outside toplevel (`requests` inside function) | Moved to top-level `try/except ImportError`; guard check at function entry |
| `except Exception` too broad | Narrowed to `except (requests.RequestException, KeyError, ValueError)` |
| `score_terms` 32 lines / complexity 7 | Extracted `_score_term` helper |
| `main` 39 lines | Extracted `_print_perplexity_result` helper |

## Not addressed

**Workflow unpinned action SHAs** (`gemini-invoke.yml`, `gemini-review.yml`, `gemini-triage.yml` — `run-gemini-cli@v0`): The `# ratchet:exclude` comment on each shows deliberate intent to track the floating `v0` tag. Pinning would require looking up the current SHA externally. Left as-is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCNBXuhcs3hWFXooZtdAfG)_